### PR TITLE
docs: real API docs for all six packages + runnable examples with CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,10 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      # Smoke-runs the numbered examples. All of them are single-node by
+      # design (deterministic); multi-node scenarios live in the private
+      # raijin-test-harness package and are excluded from this step because
+      # they are timing-sensitive. See examples/README.md.
+      - name: Examples smoke test
+        run: npm run examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased — documentation overhaul + runnable examples (2026-08-25)
+
+Documentation only, plus example scripts and a CI smoke step — no library
+source changes.
+
+- **All six per-package READMEs rewritten** from provenance-only stubs into
+  real API documentation: full export surface with signatures, quick starts,
+  and the sharp edges up front (PBFT quorum = 1 below 4 validators; the two
+  unrelated `Mempool` classes in `raijin-mempool` vs `raijin-validator`; the
+  8-byte fee convention colliding with the tx-type byte; what a
+  `DACommitment` does and doesn't prove; `encode()`'s optional-fflate
+  dependency; zeroed `stateRoot`/`receiptRoot` in produced headers). The
+  provenance notes are kept, with the stale "publish.yml now uses pnpm
+  publish" line updated to reflect the npm-workspaces conversion.
+- **Root README**: new section documenting the internal `raijin-test-harness`
+  package (what it provides, why it stays unpublished) and a pointer to the
+  new examples.
+- **`examples/`**: seven numbered, self-checking walkthroughs
+  (`01-hashing-merkle` … `07-sdk-end-to-end`) with an `examples/README.md`.
+  Root scripts `example:01`–`example:07` run them individually and
+  `examples` runs the loop. All are single-node by design so they're
+  deterministic; multi-node scenarios remain in `raijin-test-harness` and
+  are excluded on purpose (documented in `examples/README.md`).
+- **CI**: `.github/workflows/ci.yml` gains an "Examples smoke test" step
+  running `npm run examples` after build/test/typecheck.
+
 ## Unreleased — npm workspaces + Turborepo (2026-08-25)
 
 Converts the monorepo's package manager from pnpm to plain `npm` workspaces,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,18 @@ Think of it as the OP Stack, but for browsers.
 npm install
 npm run build
 npm run test
+npm run examples   # run the numbered walkthroughs in examples/
 ```
+
+## Examples
+
+[`examples/`](examples) contains seven numbered, self-checking walkthroughs —
+hashing/Merkle roots, the state machine, mempool fee ordering, data
+availability, a PBFT consensus round, the validator node lifecycle, and an
+SDK end-to-end run against an in-process node. Each runs standalone
+(`npm run example:01` … `example:07`) or all together (`npm run examples`,
+also a CI smoke step). See [examples/README.md](examples/README.md) — and
+note why they're all deliberately single-node.
 
 ## Architecture
 
@@ -53,6 +64,38 @@ raijin-core         (state machine, blocks, transactions)
 All packages are transport-agnostic, storage-agnostic, and identity-agnostic.
 The framework accepts any signing function, any key-value store, and any
 network transport (WebRTC, WebSocket, libp2p, etc.).
+
+## The test harness (`raijin-test-harness`)
+
+The seventh workspace package is internal test infrastructure, not a
+library — it's `private: true`, unscoped, and never published. It exists
+because the unit tests above only ever exercise one node at a time, and
+consensus bugs live between nodes.
+
+What it provides:
+
+- **`TestOrchestrator`** — spins up a cluster of `RaijinTestNode`s (real
+  `ValidatorNode`s, not mocks) on a shared `PartitionableNetwork` and
+  `MockTimer`, with two-phase setup so every node sees the same validator
+  set.
+- **`PartitionableNetwork` / `SeededPRNG`** — an in-memory transport that
+  can partition, heal, and (seeded) randomize delivery to reproduce
+  distributed failure modes deterministically-ish.
+- **Checkers** — invariant assertions run across the whole cluster after a
+  scenario: `NoForkChecker`, `BalanceConsistencyChecker`,
+  `EventLogIntegrityChecker`, `GossipConvergenceChecker`.
+- **Workloads** — reusable scenario drivers (`ConsensusBlockWorkload`,
+  `CreditTransferWorkload`, `MembershipChurnWorkload`) plus an
+  `EventCollector`/`ReportGenerator` timeline for post-mortem output.
+
+Why it stays unpublished: it reaches into `../../consensus/test/helpers.ts`
+for its mock network/timer (a path that only exists in this repo), and its
+multi-node tests are timing-sensitive by nature — the 11 harness tests are
+known to be flaky under load, which is acceptable for internal scenario
+testing but not something to ship. The 123 tests across the six publishable
+packages are deterministic; CI's example smoke step is also restricted to
+single-node scenarios for the same reason (see
+[examples/README.md](examples/README.md)).
 
 ## Design Principles
 

--- a/examples/01-hashing-merkle.mjs
+++ b/examples/01-hashing-merkle.mjs
@@ -1,0 +1,42 @@
+/**
+ * 01 — Hashing and Merkle roots (@johnhenry/raijin-core)
+ *
+ * SHA-256 over crypto.subtle, Merkle roots over leaf hashes, and hex
+ * round-trips. Everything is async because Web Crypto is async.
+ *
+ * Run: npm run example:01
+ */
+import assert from 'node:assert/strict'
+import { hash, hashString, merkleRoot, equal, toHex, fromHex } from '@johnhenry/raijin-core'
+
+// SHA-256 of raw bytes and of a UTF-8 string
+const digest = await hash(new Uint8Array([1, 2, 3]))
+assert.equal(digest.length, 32)
+console.log('hash([1,2,3])      =', toHex(digest))
+
+const strDigest = await hashString('raijin')
+console.log('hashString(raijin) =', toHex(strDigest))
+
+// Merkle root over leaf hashes
+const leaves = [
+  await hashString('tx-a'),
+  await hashString('tx-b'),
+  await hashString('tx-c'), // odd count — last leaf is duplicated for padding
+]
+const root = await merkleRoot(leaves)
+console.log('merkleRoot(3)      =', toHex(root))
+
+// Leaf order matters — a Merkle root commits to the ordering
+const swapped = await merkleRoot([leaves[1], leaves[0], leaves[2]])
+assert.ok(!equal(root, swapped), 'reordering leaves must change the root')
+
+// Edge cases: single leaf is returned as-is; empty input is hash of empty bytes
+assert.ok(equal(await merkleRoot([leaves[0]]), leaves[0]))
+assert.equal((await merkleRoot([])).length, 32)
+
+// Hex round-trip
+const hex = toHex(root)
+assert.ok(equal(fromHex(hex), root))
+console.log('hex round-trip ok  =', hex.slice(0, 16) + '…')
+
+console.log('01-hashing-merkle: OK')

--- a/examples/02-state-machine.mjs
+++ b/examples/02-state-machine.mjs
@@ -1,0 +1,71 @@
+/**
+ * 02 — State machine transfers and revert receipts (@johnhenry/raijin-core)
+ *
+ * Applies transactions to an InMemoryStateStore through the StateMachine.
+ * Shows a successful transfer, an insufficient-balance revert, and a
+ * nonce-mismatch revert. Failed transactions produce revert receipts —
+ * they do not throw.
+ *
+ * Run: npm run example:02
+ */
+import assert from 'node:assert/strict'
+import {
+  StateMachine,
+  InMemoryStateStore,
+  TransactionType,
+  encodeAccount,
+  toHex,
+} from '@johnhenry/raijin-core'
+
+// A signature verifier is injected — this example trusts everything.
+// Example 07 shows a real Ed25519 verifier.
+const trustEverything = { verify: async () => true }
+
+const store = new InMemoryStateStore()
+const sm = new StateMachine(store, trustEverything)
+
+const alice = new Uint8Array(32).fill(1)
+const bob = new Uint8Array(32).fill(2)
+
+// Fund alice directly in the store (genesis-style). Account state lives
+// under the 'account:' namespace prefix.
+const prefix = new TextEncoder().encode('account:')
+const aliceKey = new Uint8Array([...prefix, ...alice])
+await store.put(aliceKey, encodeAccount({ balance: 1000n, nonce: 0n, reputation: 0n }))
+
+function transfer(from, to, value, nonce) {
+  return {
+    from,
+    to,
+    value,
+    nonce,
+    data: new Uint8Array([TransactionType.Transfer]), // first data byte = tx type
+    signature: new Uint8Array(64),
+    chainId: 1n,
+  }
+}
+
+// 1. Successful transfer
+const r1 = await sm.applyTransaction(transfer(alice, bob, 250n, 0n), 0)
+assert.equal(r1.status, 'success')
+console.log('transfer 250:', r1.status, toHex(r1.txHash).slice(0, 16) + '…')
+
+// 2. Overspend — reverts, state untouched
+const r2 = await sm.applyTransaction(transfer(alice, bob, 10_000n, 1n), 1)
+assert.equal(r2.status, 'revert')
+console.log('overspend:   ', r2.status, '—', r2.revertReason)
+
+// 3. Wrong nonce — reverts (the failed tx above did NOT consume nonce 1)
+const r3 = await sm.applyTransaction(transfer(alice, bob, 1n, 5n), 2)
+assert.equal(r3.status, 'revert')
+console.log('bad nonce:   ', r3.status, '—', r3.revertReason)
+
+// Final balances
+const a = await sm.getAccount(alice)
+const b = await sm.getAccount(bob)
+assert.equal(a.balance, 750n)
+assert.equal(b.balance, 250n)
+console.log('alice:', a, '\nbob:  ', b)
+console.log('state root =', toHex(await sm.stateRoot()).slice(0, 16) + '…')
+
+console.log('02-state-machine: OK')

--- a/examples/03-mempool-ordering.mjs
+++ b/examples/03-mempool-ordering.mjs
@@ -1,0 +1,77 @@
+/**
+ * 03 — Mempool fee ordering and eviction (@johnhenry/raijin-mempool)
+ *
+ * The default fee convention: the FIRST 8 BYTES of tx.data are the fee,
+ * big-endian. This collides with the state machine's convention (first
+ * data byte = transaction type) — real deployments supply their own
+ * FeeExtractor. Here we use the default to show the mechanics.
+ *
+ * Run: npm run example:03
+ */
+import assert from 'node:assert/strict'
+import { Mempool, orderByFee, defaultFeeExtractor } from '@johnhenry/raijin-mempool'
+
+function encodeFee(fee) {
+  const bytes = new Uint8Array(8)
+  let v = fee
+  for (let i = 7; i >= 0; i--) {
+    bytes[i] = Number(v & 0xffn)
+    v >>= 8n
+  }
+  return bytes
+}
+
+function tx(senderId, nonce, fee) {
+  const from = new Uint8Array(32)
+  from[0] = senderId
+  return {
+    from,
+    nonce,
+    to: new Uint8Array(32),
+    value: 0n,
+    data: encodeFee(fee),
+    signature: new Uint8Array(64),
+    chainId: 1n,
+  }
+}
+
+const pool = new Mempool({
+  verifier: async () => true, // inject your real signature check here
+  maxSize: 3,
+})
+
+const dropped = []
+pool.onDropped((t, reason) => dropped.push(reason))
+
+await pool.submit(tx(1, 0n, 10n))
+await pool.submit(tx(2, 0n, 50n))
+await pool.submit(tx(3, 0n, 30n))
+
+// pending() is fee-descending
+console.log('pending fees:', pool.pending().map(defaultFeeExtractor)) // [50n, 30n, 10n]
+assert.deepEqual(pool.pending().map(defaultFeeExtractor), [50n, 30n, 10n])
+
+// Pool is full (maxSize 3). A higher-fee tx evicts the lowest…
+await pool.submit(tx(4, 0n, 99n))
+assert.deepEqual(pool.pending().map(defaultFeeExtractor), [99n, 50n, 30n])
+console.log('after 99n submit:', pool.pending().map(defaultFeeExtractor), '— dropped:', dropped)
+
+// …but an EQUAL-fee tx does not (eviction requires strictly higher fee)
+const accepted = await pool.submit(tx(5, 0n, 30n))
+assert.equal(accepted, false)
+console.log('equal-fee submit accepted?', accepted, '— reason:', dropped.at(-1))
+
+// Duplicate sender+nonce is rejected regardless of fee
+const dup = await pool.submit(tx(4, 0n, 500n))
+assert.equal(dup, false)
+assert.equal(dropped.at(-1), 'duplicate')
+
+// Proposers take the top-N by fee
+console.log('top-2 for block:', pool.pendingForProposer(2).map(defaultFeeExtractor))
+assert.equal(pool.pendingForProposer(2).length, 2)
+
+// orderByFee is usable standalone, with any fee extractor
+const byValue = orderByFee(pool.pending(), (t) => t.value)
+assert.equal(byValue.length, pool.size)
+
+console.log('03-mempool-ordering: OK')

--- a/examples/04-da-local.mjs
+++ b/examples/04-da-local.mjs
@@ -1,0 +1,60 @@
+/**
+ * 04 — Data availability with LocalDA and encode/decode (@johnhenry/raijin-da)
+ *
+ * submit() returns a DACommitment (layer, height, index, content hash);
+ * retrieve() gets the bytes back; verify() re-hashes what's stored and
+ * compares against the commitment hash.
+ *
+ * encode()/decode() wrap payloads with a magic header and compress via
+ * fflate WHEN INSTALLED (it's optional) — output differs between
+ * environments with and without fflate, but decode() always handles the
+ * raw form.
+ *
+ * Run: npm run example:04
+ */
+import assert from 'node:assert/strict'
+import { LocalDA, encode, decode } from '@johnhenry/raijin-da'
+import { equal, toHex } from '@johnhenry/raijin-core'
+
+const da = new LocalDA()
+const blockBytes = new TextEncoder().encode(JSON.stringify({ number: 1, txs: ['a', 'b'] }))
+
+// Encode for DA submission (adds "RJC"/"RJR" magic; compresses if fflate present)
+const encoded = await encode(blockBytes)
+console.log('payload', blockBytes.length, 'bytes → encoded', encoded.length,
+  'bytes (magic:', String.fromCharCode(...encoded.slice(0, 3)) + ')')
+
+// Submit → commitment
+const commitment = await da.submit(encoded)
+console.log('commitment:', {
+  layer: commitment.layer,
+  height: commitment.height,
+  index: commitment.index,
+  hash: toHex(commitment.hash).slice(0, 16) + '…',
+})
+assert.equal(commitment.layer, 'local')
+
+// Retrieve + decode round-trip
+const retrieved = await da.retrieve(commitment)
+const decoded = await decode(retrieved)
+assert.ok(equal(decoded, blockBytes), 'round-trip must return the original bytes')
+console.log('round-trip ok:', new TextDecoder().decode(decoded))
+
+// verify() — true for a real commitment…
+assert.equal(await da.verify(commitment), true)
+
+// …false for a commitment whose hash matches nothing stored.
+// Note what verify() proves: "this backend has bytes matching this hash".
+// It does NOT prove inclusion at a particular height/index.
+const forged = { ...commitment, hash: new Uint8Array(32) }
+assert.equal(await da.verify(forged), false)
+console.log('forged commitment verifies?', await da.verify(forged))
+
+// Heights advance only when you say so (LocalDA simulates block boundaries).
+// Storage is content-addressed: resubmitting identical bytes reuses the slot.
+da.nextBlock()
+const c2 = await da.submit(await encode(new TextEncoder().encode('block 2')))
+assert.equal(c2.height, 1n)
+console.log('after nextBlock(): height =', c2.height, 'stored blobs =', da.size)
+
+console.log('04-da-local: OK')

--- a/examples/05-consensus-round.mjs
+++ b/examples/05-consensus-round.mjs
@@ -1,0 +1,79 @@
+/**
+ * 05 — PBFT quorum math and a single-validator consensus round
+ *      (@johnhenry/raijin-consensus)
+ *
+ * First: the quorum table. quorum = 2f+1 with f = floor((n-1)/3), so with
+ * 1, 2, or 3 validators f = 0 and quorum = 1 — a single node finalizes
+ * alone. Byzantine fault tolerance only starts at n = 4.
+ *
+ * Then: a full propose → pre-prepare → prepare → commit → finalize round
+ * with one validator (quorum 1), driven entirely in-process. Multi-node
+ * rounds live in the repo's test-harness package.
+ *
+ * Run: npm run example:05
+ */
+import assert from 'node:assert/strict'
+import { StateMachine, InMemoryStateStore } from '@johnhenry/raijin-core'
+import { PBFTConsensus, ValidatorSet, PBFTPhase } from '@johnhenry/raijin-consensus'
+
+// ── Quorum table ──────────────────────────────────────────────────────
+console.log(' n | maxFaults | quorum')
+for (let n = 1; n <= 7; n++) {
+  const set = new ValidatorSet(
+    Array.from({ length: n }, (_, i) => new Uint8Array(32).fill(i + 1)),
+  )
+  console.log(String(n).padStart(2), '|', String(set.maxFaults).padStart(9), '|', set.quorumSize())
+}
+
+// ── Single-validator round ────────────────────────────────────────────
+const me = new Uint8Array(32).fill(7)
+const validators = new ValidatorSet([me])
+
+const store = new InMemoryStateStore()
+const stateMachine = new StateMachine(store, { verify: async () => true })
+
+// Transport and timer are injected. Single node: broadcast goes nowhere,
+// and a manual timer means nothing fires unless we drive it.
+const transport = { broadcast() {}, send() {}, onMessage() {} }
+const manualTimer = { set: () => ({}), clear: () => {} }
+
+const consensus = new PBFTConsensus({
+  identity: me,
+  validators,
+  transport,
+  timer: manualTimer,
+  stateMachine,
+  sign: async () => new Uint8Array(64), // inject a real signer in production
+})
+
+const finalized = new Promise((resolve) => {
+  consensus.onBlockFinalized((block, receipts) => resolve({ block, receipts }))
+})
+
+consensus.start()
+assert.equal(consensus.isLeader, true) // sole validator = leader for view 0
+assert.equal(consensus.phase, PBFTPhase.Idle)
+
+await consensus.propose({
+  header: {
+    number: 1n,
+    parentHash: new Uint8Array(32),
+    stateRoot: new Uint8Array(32),
+    txRoot: new Uint8Array(32),
+    receiptRoot: new Uint8Array(32),
+    timestamp: Date.now(),
+    proposer: me,
+  },
+  transactions: [],
+  signatures: [],
+})
+
+// Quorum is 1, so our own PREPARE and COMMIT complete the round.
+const { block, receipts } = await finalized
+console.log('finalized block', block.header.number, 'with', receipts.length, 'receipts')
+assert.equal(block.header.number, 1n)
+assert.equal(consensus.phase, PBFTPhase.Idle) // reset for the next round
+assert.equal(consensus.currentSequence, 1n)
+
+consensus.stop()
+console.log('05-consensus-round: OK')

--- a/examples/06-validator-lifecycle.mjs
+++ b/examples/06-validator-lifecycle.mjs
@@ -1,0 +1,89 @@
+/**
+ * 06 — ValidatorNode lifecycle (@johnhenry/raijin-validator)
+ *
+ * The composition root: state machine + PBFT consensus + FIFO mempool +
+ * block producer wired together. Single validator, real timers, one
+ * block: submit a transaction, let the block timer fire, watch it
+ * finalize, then stop cleanly.
+ *
+ * Run: npm run example:06
+ */
+import assert from 'node:assert/strict'
+import {
+  InMemoryStateStore,
+  TransactionType,
+  encodeAccount,
+  toHex,
+} from '@johnhenry/raijin-core'
+import { ValidatorNode } from '@johnhenry/raijin-validator'
+
+const alice = new Uint8Array(32).fill(1)
+const bob = new Uint8Array(32).fill(2)
+
+// Fund alice at genesis
+const store = new InMemoryStateStore()
+const prefix = new TextEncoder().encode('account:')
+await store.put(
+  new Uint8Array([...prefix, ...alice]),
+  encodeAccount({ balance: 10_000n, nonce: 0n, reputation: 0n }),
+)
+
+const node = new ValidatorNode({
+  identity: {
+    publicKey: alice,
+    sign: async () => new Uint8Array(64), // consensus-message signer
+    verify: { verify: async () => true }, // transaction-signature verifier
+  },
+  // Single node: no peers to talk to. With >1 validator this must be a
+  // real transport (WebRTC, WebSocket, …).
+  transport: { broadcast() {}, send() {}, onMessage() {} },
+  // Real timers drive block production
+  timer: {
+    set: (ms, cb) => setTimeout(cb, ms),
+    clear: (h) => clearTimeout(h),
+  },
+  store,
+  validators: [alice], // must include self, or this node can never lead
+  blockTime: 50,
+  maxTxPerBlock: 100,
+})
+
+const finalized = new Promise((resolve) => {
+  node.onBlockFinalized((block, receipts) => resolve({ block, receipts }))
+})
+
+node.start()
+assert.equal(node.running, true)
+assert.equal(node.latestBlock, null)
+
+// submitTransaction does NOT verify signatures — invalid transactions are
+// only caught at execution, where they produce revert receipts.
+const txHash = await node.submitTransaction({
+  from: alice,
+  to: bob,
+  value: 500n,
+  nonce: 0n,
+  data: new Uint8Array([TransactionType.Transfer]),
+  signature: new Uint8Array(64),
+  chainId: 1n,
+})
+console.log('submitted tx', txHash.slice(0, 16) + '…', '— mempool size:', node.mempool.size)
+
+// The block timer fires after ~50ms, the producer pulls the mempool,
+// proposes, and the single-validator quorum finalizes immediately.
+const { block, receipts } = await finalized
+console.log('finalized block', block.header.number,
+  '| txs:', block.transactions.length,
+  '| receipt:', receipts[0].status)
+assert.equal(receipts[0].status, 'success')
+assert.equal(node.mempool.size, 0) // included txs are removed
+assert.equal(node.latestBlock, block)
+
+const bobAccount = await node.stateMachine.getAccount(bob)
+assert.equal(bobAccount.balance, 500n)
+console.log('bob balance:', bobAccount.balance, '| state root:',
+  toHex(await node.stateMachine.stateRoot()).slice(0, 16) + '…')
+
+node.stop()
+assert.equal(node.running, false)
+console.log('06-validator-lifecycle: OK')

--- a/examples/07-sdk-end-to-end.mjs
+++ b/examples/07-sdk-end-to-end.mjs
@@ -1,0 +1,126 @@
+/**
+ * 07 — SDK end-to-end against an in-process node (@johnhenry/raijin-sdk)
+ *
+ * The full path: Wallet (real Ed25519 via Web Crypto) → signed
+ * transaction → RaijinClient → ClientTransport → ValidatorNode →
+ * finalized block → receipt → account query. Signatures are actually
+ * verified here, unlike the earlier examples.
+ *
+ * Run: npm run example:07
+ */
+import assert from 'node:assert/strict'
+import {
+  InMemoryStateStore,
+  encodeAccount,
+  encodeTx,
+  hash,
+  equal,
+  toHex,
+} from '@johnhenry/raijin-core'
+import { ValidatorNode } from '@johnhenry/raijin-validator'
+import { RaijinClient, Wallet } from '@johnhenry/raijin-sdk'
+
+// ── Real Ed25519 signature verification (Node 24+ / modern browsers) ──
+const ed25519Verifier = {
+  async verify(message, signature, publicKey) {
+    try {
+      const key = await globalThis.crypto.subtle.importKey(
+        'raw', publicKey, { name: 'Ed25519' }, false, ['verify'],
+      )
+      return await globalThis.crypto.subtle.verify({ name: 'Ed25519' }, key, signature, message)
+    } catch {
+      return false
+    }
+  },
+}
+
+// ── Wallets ───────────────────────────────────────────────────────────
+const validatorWallet = await Wallet.generate()
+const userWallet = await Wallet.generate()
+const merchant = new Uint8Array(32).fill(9)
+
+// ── One in-process validator node ─────────────────────────────────────
+const store = new InMemoryStateStore()
+const prefix = new TextEncoder().encode('account:')
+await store.put(
+  new Uint8Array([...prefix, ...userWallet.publicKey]),
+  encodeAccount({ balance: 1_000n, nonce: 0n, reputation: 0n }),
+)
+
+const node = new ValidatorNode({
+  identity: {
+    publicKey: validatorWallet.publicKey,
+    sign: (msg) => validatorWallet.sign(msg),
+    verify: ed25519Verifier,
+  },
+  transport: { broadcast() {}, send() {}, onMessage() {} },
+  timer: { set: () => ({}), clear: () => {} }, // manual: we drive production below
+  store,
+  validators: [validatorWallet.publicKey],
+})
+node.start()
+
+// ── A ClientTransport backed by the in-process node ───────────────────
+// In a real deployment this is the network boundary (HTTP/WebRTC/…).
+const transport = {
+  async submitTransaction(tx) {
+    const wantHash = await hash(encodeTx(tx))
+    const receiptPromise = new Promise((resolve) => {
+      node.onBlockFinalized((_block, receipts) => {
+        const r = receipts.find((r) => equal(r.txHash, wantHash))
+        if (r) resolve(r)
+      })
+    })
+    await node.submitTransaction(tx)
+    await node.blockProducer.produceBlock() // manual timer → produce explicitly
+    return receiptPromise
+  },
+  async getAccount(address) {
+    return node.stateMachine.getAccount(address)
+  },
+  async getBlock(number) {
+    const latest = node.latestBlock
+    return latest && latest.header.number === number ? latest : null
+  },
+  onBlock(handler) {
+    node.onBlockFinalized((block) => handler(block))
+    return () => {}
+  },
+}
+
+// ── The developer-facing surface ──────────────────────────────────────
+const client = new RaijinClient(transport)
+
+const unsub = client.subscribe((block) =>
+  console.log('new block:', block.header.number, '| txs:', block.transactions.length))
+
+// Build and sign a transfer — Wallet signs the canonical tx encoding
+const tx = await userWallet.buildTx({ to: merchant, value: 250n, nonce: 0n })
+assert.equal(tx.signature.length, 64)
+
+const receipt = await client.submitTransaction(tx)
+console.log('receipt:', receipt.status, toHex(receipt.txHash).slice(0, 16) + '…')
+assert.equal(receipt.status, 'success')
+
+// Query resulting state through the client
+const user = await client.getAccount(userWallet.publicKey)
+const shop = await client.getAccount(merchant)
+assert.equal(user.balance, 750n)
+assert.equal(user.nonce, 1n)
+assert.equal(shop.balance, 250n)
+console.log('user:', user, '\nmerchant:', shop)
+
+const block1 = await client.getBlock(1n)
+assert.ok(block1)
+assert.equal(await client.getBlock(99n), null)
+
+// A tampered transaction fails signature verification → revert receipt
+const evil = await userWallet.buildTx({ to: merchant, value: 1n, nonce: 1n })
+evil.value = 999n // mutate after signing
+const evilReceipt = await client.submitTransaction(evil)
+assert.equal(evilReceipt.status, 'revert')
+console.log('tampered tx:', evilReceipt.status, '—', evilReceipt.revertReason)
+
+unsub()
+node.stop()
+console.log('07-sdk-end-to-end: OK')

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# Raijin examples
+
+Runnable, self-checking walkthroughs of the six publishable packages. Each one is a plain Node ES module that prints what it's doing and asserts the results — if it exits 0, everything it claims actually happened.
+
+## Prerequisites
+
+```bash
+npm ci
+npm run build   # examples import the built packages via workspace links
+```
+
+Node ≥ 24 (example 07 uses Web Crypto Ed25519).
+
+## The examples
+
+| # | File | Shows |
+| --- | --- | --- |
+| 01 | `01-hashing-merkle.mjs` | `@johnhenry/raijin-core` hashing: SHA-256, Merkle roots (odd-leaf padding, order sensitivity), hex round-trips |
+| 02 | `02-state-machine.mjs` | `StateMachine` + `InMemoryStateStore`: genesis funding, a successful transfer, insufficient-balance and nonce-mismatch revert receipts |
+| 03 | `03-mempool-ordering.mjs` | `@johnhenry/raijin-mempool`: the 8-byte fee convention, fee-descending ordering, strict-inequality eviction, duplicate rejection |
+| 04 | `04-da-local.mjs` | `@johnhenry/raijin-da`: `encode`/`decode` magic headers, `LocalDA` submit/retrieve/verify, what commitment verification does and doesn't prove |
+| 05 | `05-consensus-round.mjs` | `@johnhenry/raijin-consensus`: the quorum table (n=1..7), then a full single-validator PBFT round from `propose()` to finalization |
+| 06 | `06-validator-lifecycle.mjs` | `@johnhenry/raijin-validator`: a one-node chain with real timers — submit, block production, finalization, mempool pruning, clean stop |
+| 07 | `07-sdk-end-to-end.mjs` | `@johnhenry/raijin-sdk`: `Wallet` (real Ed25519) → `RaijinClient` → in-process `ValidatorNode`, including a tampered-tx revert |
+
+Run one:
+
+```bash
+npm run example:06
+```
+
+Run all:
+
+```bash
+npm run examples
+```
+
+## Why every example is single-node
+
+All seven examples run one validator in one process, on purpose. Single-validator PBFT has quorum 1 (see example 05), so consensus completes deterministically with no cross-node timing — which makes these examples safe to run in CI as a smoke test (`npm run examples` is a CI step).
+
+Multi-node scenarios (leader crashes, partitions, gossip convergence, membership churn) are exercised by the internal `raijin-test-harness` package instead. Those tests coordinate several nodes over a simulated network and are timing-sensitive — they are deliberately **excluded** from the examples loop and the CI smoke step so a scheduling hiccup can't fail an unrelated change. Run them directly with `npm run test -w raijin-test-harness` if you want them.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,15 @@
     "build": "turbo run build",
     "test": "turbo run test",
     "typecheck": "turbo run typecheck",
-    "clean": "turbo run clean"
+    "clean": "turbo run clean",
+    "example:01": "node examples/01-hashing-merkle.mjs",
+    "example:02": "node examples/02-state-machine.mjs",
+    "example:03": "node examples/03-mempool-ordering.mjs",
+    "example:04": "node examples/04-da-local.mjs",
+    "example:05": "node examples/05-consensus-round.mjs",
+    "example:06": "node examples/06-validator-lifecycle.mjs",
+    "example:07": "node examples/07-sdk-end-to-end.mjs",
+    "examples": "for f in examples/[0-9]*.mjs; do echo \"== $f\"; node \"$f\" || exit 1; done"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/consensus/README.md
+++ b/packages/consensus/README.md
@@ -2,7 +2,7 @@
 
 PBFT consensus and leader rotation for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
-Implements a simplified Practical Byzantine Fault Tolerance protocol with rotating leader selection and view changes for leader failure.
+Implements a simplified Practical Byzantine Fault Tolerance protocol: the leader broadcasts PRE-PREPARE with a proposed block, validators answer PREPARE, then COMMIT, and the block finalizes once `2f+1` commits are collected. View changes rotate the leader when it stops proposing. Transport and timers are injected, so the engine runs over WebRTC, WebSockets, or an in-memory bus, and tests can drive time deterministically.
 
 ## Install
 
@@ -10,11 +10,90 @@ Implements a simplified Practical Byzantine Fault Tolerance protocol with rotati
 npm install @johnhenry/raijin-consensus
 ```
 
+## Quorum math — read this before choosing a validator count
+
+`quorumSize() = 2f + 1` with `f = floor((n - 1) / 3)`:
+
+| validators (n) | tolerated faults (f) | quorum |
+| --- | --- | --- |
+| 1–3 | 0 | **1** |
+| 4–6 | 1 | 3 |
+| 7–9 | 2 | 5 |
+
+With 1, 2, or 3 validators, **a single node meets quorum and finalizes alone** — there is no Byzantine tolerance below `n = 4`. That's convenient for demos and fatal if you assumed otherwise.
+
+Two more sharp edges:
+
+- **Messages are trusted from the transport.** The engine checks that `from` is in the validator set, but nothing verifies that the transport reported `from` honestly, and the signatures carried on COMMIT messages are collected, not verified. Authentication is your transport's job.
+- **The engine never builds blocks.** The leader's block timer fires into a no-op; something external (`BlockProducer` in `@johnhenry/raijin-validator`) must construct a block and call `propose()`.
+
+## Quick start
+
+```js
+import { StateMachine, InMemoryStateStore } from '@johnhenry/raijin-core'
+import { PBFTConsensus, ValidatorSet } from '@johnhenry/raijin-consensus'
+
+const consensus = new PBFTConsensus({
+  identity: myPublicKey,             // 32 bytes
+  validators: new ValidatorSet([myPublicKey, peerA, peerB, peerC]),
+  transport,                         // NetworkTransport — your WebRTC/WebSocket bridge
+  timer: { set: (ms, cb) => setTimeout(cb, ms), clear: clearTimeout },
+  stateMachine: new StateMachine(new InMemoryStateStore(), verifier),
+  sign: (msg) => wallet.sign(msg),
+  blockTime: 2000,                   // default 2000
+  viewTimeout: 10000,                // default 10000
+})
+
+consensus.onBlockFinalized((block, receipts) => console.log('final', block.header.number))
+consensus.onViewChange((view) => console.log('new view', view))
+consensus.start()
+
+if (consensus.isLeader) await consensus.propose(block)
+```
+
+`propose()` throws unless this node is the current leader **and** `phase` is `Idle` — one consensus round at a time. On finalization the engine applies the block via `stateMachine.applyBlock()`, notifies handlers, and resets to `Idle`.
+
+## API
+
+### `PBFTConsensus`
+
+`new PBFTConsensus(config: PBFTConfig)` — config fields: `identity`, `validators`, `transport`, `timer`, `stateMachine`, `sign`, optional `blockTime` (ms, default 2000), optional `viewTimeout` (ms, default 10000).
+
+| Member | Purpose |
+| --- | --- |
+| `start()` / `stop()` | Arm/clear timers and begin/stop processing messages. Messages received while stopped are dropped. |
+| `propose(block): Promise<void>` | Leader-only. Broadcasts PRE-PREPARE (+ its own PREPARE) and increments the sequence. |
+| `onBlockFinalized(handler)` | `(block, receipts) => void` after quorum commit + state application. |
+| `onViewChange(handler)` | `(newView: bigint) => void` after a view change takes effect. |
+| `currentView` / `currentSequence` | `bigint` counters. |
+| `phase` | `PBFTPhase`: `Idle → PrePrepared → Prepared → Committed → Idle`. |
+| `isLeader` / `currentLeader` | Leader for the current view (round-robin over the validator set). |
+| `running` | Whether `start()` has been called. |
+
+View changes: if the view timer expires without progress, the node broadcasts `view-change` for `view + 1`; once `quorumSize()` view-change messages accumulate, everyone rotates, clears in-flight rounds, and the new leader takes over.
+
+### `ValidatorSet`
+
+`new ValidatorSet(validators?: Uint8Array[])` — ordered set of 32-byte public keys.
+
+- `add(pubkey)` / `remove(pubkey)` / `has(pubkey)` — membership; `add` returns `false` on duplicates.
+- `leaderForView(view)` — deterministic round-robin: `validators[view % n]`. Throws on an empty set.
+- `quorumSize()` / `maxFaults` — the math above.
+- `size` / `all()` / `at(index)` — inspection.
+
+Every node must construct its `ValidatorSet` with the **same keys in the same order**, or leader election disagrees and nothing finalizes.
+
+### Types
+
+`PBFTConfig`, `PBFTPhase`, `NetworkTransport` (`broadcast`/`send`/`onMessage`), `ConsensusTimer` + `TimerHandle` (`set`/`clear` — injectable for deterministic tests), and the message union `ConsensusMessage` = `PrePrepareMessage | PrepareMessage | CommitMessage | ViewChangeMessage | NewViewMessage`.
+
+If your transport serializes to JSON, remember consensus messages carry `bigint`s and `Uint8Array`s — you need a replacer/reviver pair (see `test/helpers.ts` in the repo for a working one).
+
 ## Provenance
 
 Previously published unscoped as [`raijin-consensus`](https://www.npmjs.com/package/raijin-consensus): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).
 
-Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The underlying publish-workflow bug is fixed for good as part of this migration (`.github/workflows/publish.yml` now uses `pnpm publish`). See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
+Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The `workspace:*` publish bug can no longer recur: the monorepo has since converted to npm workspaces with real semver ranges, and releases go out via `npm publish --workspaces`. See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,13 +2,88 @@
 
 State machine, blocks, and transactions for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
-Zero external dependencies. Uses only `globalThis.crypto.subtle`. Works in the browser and in Node.js.
+Zero external dependencies. Uses only `globalThis.crypto.subtle`. Works in the browser and in Node.js. Every other Raijin package depends on this one; if you only need the types, hashing, or the state transition function, this is the only install.
 
 ## Install
 
 ```bash
 npm install @johnhenry/raijin-core
 ```
+
+## Quick start
+
+```js
+import { StateMachine, InMemoryStateStore } from '@johnhenry/raijin-core'
+
+const store = new InMemoryStateStore()
+const sm = new StateMachine(store, myEd25519Verifier) // you inject signature verification
+
+const receipt = await sm.applyTransaction(signedTx, 0)
+// { txHash, status: 'success' | 'revert', revertReason?, index }
+```
+
+Failed transactions do not throw — they return `status: 'revert'` receipts with a `revertReason` (`'invalid signature'`, `'nonce mismatch: …'`, `'insufficient balance'`, …).
+
+## Things to know first
+
+- **Everything is async.** Hashing goes through `crypto.subtle`, so `hash`, `merkleRoot`, `stateRoot`, and every state-machine call return promises.
+- **The first byte of `tx.data` selects the transaction type.** Empty `data` defaults to `Transfer`. Only `Transfer` (0x01) and `ReputationAttest` (0x02) execute real logic today; every other `TransactionType` value is a placeholder that just increments the sender's nonce.
+- **`InMemoryStateStore.root()` is a flat hash of all entries, not a Merkle trie.** It's deterministic and good for equality checks across nodes, but it cannot produce inclusion proofs.
+- **Byte-identity everywhere.** Addresses are 32-byte public keys as `Uint8Array`s; account state lives under namespaced keys like `'account:' + pubkey`. Seed genesis balances with `encodeAccount` + `store.put` (see [`examples/02-state-machine.mjs`](https://github.com/johnhenry/raijin/blob/main/examples/02-state-machine.mjs)).
+
+## API
+
+### Types
+
+| Export | Shape |
+| --- | --- |
+| `Transaction` | `{ from, nonce, to, value, data, signature, chainId }` — `from`/`to` are 32-byte keys, amounts are `bigint` |
+| `Block` | `{ header: BlockHeader, transactions: Transaction[], signatures: Uint8Array[] }` |
+| `BlockHeader` | `{ number, parentHash, stateRoot, txRoot, receiptRoot, timestamp, proposer }` |
+| `Account` | `{ balance: bigint, nonce: bigint, reputation: bigint }` |
+| `TransactionReceipt` | `{ txHash, status, revertReason?, index }` |
+| `TransactionType` | enum: `Transfer = 0x01` … `EscrowRefund = 0x0f` (15 values; most are placeholders, see above) |
+| `StateStore` | interface: `get/put/delete/root/snapshot/revert` — implement over IndexedDB, OPFS, … |
+| `StateSnapshot` | `{ id: number }` |
+| `SignatureVerifier` | `{ verify(message, signature, publicKey): Promise<boolean> }` |
+| `TransactionSigner` | `{ publicKey, sign(message): Promise<Uint8Array> }` |
+
+### `StateMachine`
+
+```ts
+new StateMachine(store: StateStore, verifier: SignatureVerifier)
+```
+
+- `applyTransaction(tx, index): Promise<TransactionReceipt>` — verifies the signature over `encodeTx(tx)`, checks the nonce against the sender's account, dispatches on `tx.data[0]`, and writes state. Reverts are receipts, not exceptions.
+- `applyBlock(block): Promise<TransactionReceipt[]>` — applies each transaction in order. Reverted transactions stay in the block with revert receipts; executors check preconditions before writing, so a reverted transaction leaves no partial state. There is no block-level rollback.
+- `getAccount(address): Promise<Account>` — returns a zero account (`0n/0n/0n`) for unknown addresses.
+- `stateRoot(): Promise<Uint8Array>` — delegates to `store.root()`.
+
+### `InMemoryStateStore`
+
+`StateStore` implementation backed by a `Map`, with full `snapshot()`/`revert()` support and a `size` getter. Fine for tests and small state; swap in a persistent store for anything real.
+
+### Hashing — `hash`, `hashString`, `merkleRoot`, `equal`, `toHex`, `fromHex`
+
+```js
+import { hashString, merkleRoot, toHex } from '@johnhenry/raijin-core'
+
+const root = await merkleRoot([await hashString('tx-a'), await hashString('tx-b')])
+toHex(root) // '9c31…'
+```
+
+- `hash(data)` / `hashString(str)` — SHA-256, returns 32 bytes.
+- `merkleRoot(leaves)` — binary tree over leaf hashes; odd levels duplicate the last leaf. A single leaf is returned **as-is** (no extra hash), and `[]` yields `hash(empty)`. There is no leaf/node domain separation — don't use this where second-preimage games matter.
+- `equal(a, b)` — byte-wise comparison (not constant-time).
+- `toHex` / `fromHex` — lowercase hex round-trip.
+
+### Encoding — `encodeBigInt`, `decodeBigInt`, `encodeBytes`, `decodeBytes`, `encodeTx`, `encodeTxSigned`, `encodeAccount`, `decodeAccount`
+
+Deterministic canonical binary encoding (LEB128 varints + length prefixes). `encodeTx(tx)` covers everything **except** the signature — it's the exact byte string that gets signed and that receipts hash. `encodeTxSigned(tx)` appends the signature and is what block producers hash for the tx Merkle root. The decoders return `[value, bytesConsumed]` pairs.
+
+### Errors
+
+`RaijinError` base class, plus `InvalidTransactionError`, `InvalidBlockError`, `StateError`, `InsufficientBalanceError`. The state machine's normal failure path is revert receipts; these classes are for out-of-band failures.
 
 ## Provenance
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -81,6 +81,23 @@ toHex(root) // '9c31…'
 
 Deterministic canonical binary encoding (LEB128 varints + length prefixes). `encodeTx(tx)` covers everything **except** the signature — it's the exact byte string that gets signed and that receipts hash. `encodeTxSigned(tx)` appends the signature and is what block producers hash for the tx Merkle root. The decoders return `[value, bytesConsumed]` pairs.
 
+### Genesis funding
+
+There is no genesis-block concept — initial state is whatever you write to the store before the first block. Accounts live under the `'account:'` namespace:
+
+```js
+import { InMemoryStateStore, encodeAccount } from '@johnhenry/raijin-core'
+
+const store = new InMemoryStateStore()
+const prefix = new TextEncoder().encode('account:')
+await store.put(
+  new Uint8Array([...prefix, ...alicePublicKey]),
+  encodeAccount({ balance: 1_000n, nonce: 0n, reputation: 0n }),
+)
+```
+
+Do this identically on every node (before `start()`), or their state roots diverge from block one.
+
 ### Errors
 
 `RaijinError` base class, plus `InvalidTransactionError`, `InvalidBlockError`, `StateError`, `InsufficientBalanceError`. The state machine's normal failure path is revert receipts; these classes are for out-of-band failures.

--- a/packages/da/README.md
+++ b/packages/da/README.md
@@ -1,8 +1,10 @@
 # @johnhenry/raijin-da
 
-Data availability abstraction with pluggable backends (Celestia, ETH blobs) for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
+Data availability abstraction with pluggable backends for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
-`viem` is an optional peer dependency, needed only for the ETH-blobs backend.
+One interface, three backends: `LocalDA` (in-memory, for dev/tests), `CelestiaDA` (talks to a Celestia light node's REST API), and `EthBlobDA` (EIP-4844 — currently a documented stub). Plus `encode()`/`decode()` for compressing block data before submission.
+
+`viem` is an optional peer dependency, needed only if you go on to implement the ETH-blobs backend.
 
 ## Install
 
@@ -10,11 +12,81 @@ Data availability abstraction with pluggable backends (Celestia, ETH blobs) for 
 npm install @johnhenry/raijin-da
 ```
 
+## What a commitment does and does not prove
+
+`submit()` returns a `DACommitment`: `{ layer, height, index, hash }`, where `hash` is the SHA-256 of the submitted bytes. `verify(commitment)` retrieves whatever the backend has for that hash and re-hashes it. So:
+
+- **It proves**: "this backend currently serves bytes matching this content hash."
+- **It does not prove**: inclusion at `height`/`index` (LocalDA's height is a local counter you advance manually; CelestiaDA always reports `index: 0`), nor availability over time, nor anything a light client could check without refetching the full data. There are no inclusion/KZG proofs here.
+
+Other traps:
+
+- **`EthBlobDA` throws on every method.** It exists to pin the interface and document the implementation path (viem blob transactions, KZG setup, Beacon API retrieval); the error messages are the TODO list. Ethereum blobs are also pruned after ~18 days — plan for archival.
+- **`encode()` output depends on the environment.** If the optional `fflate` package is importable, payloads that shrink get deflate-compressed with an `RJC` magic prefix; otherwise raw bytes with `RJR`. `decode()` of an `RJC` payload **throws if fflate is absent** — if writers may compress, every reader needs fflate too.
+- **`CelestiaDA` needs a running light node** (default endpoint `http://localhost:26658`, usually with an auth token). It does not embed one.
+
+## Quick start
+
+```js
+import { LocalDA, encode, decode } from '@johnhenry/raijin-da'
+
+const da = new LocalDA()
+
+const payload = await encode(blockBytes)      // magic header + optional compression
+const commitment = await da.submit(payload)   // { layer: 'local', height, index, hash }
+
+const roundTrip = await decode(await da.retrieve(commitment))
+await da.verify(commitment)                   // true
+```
+
+Swapping backends is a one-line change:
+
+```js
+import { CelestiaDA } from '@johnhenry/raijin-da'
+
+const da = new CelestiaDA({
+  namespace: '00c0ffee00c0ffee',      // required, 8-byte hex namespace
+  endpoint: 'http://localhost:26658', // default
+  authToken: process.env.CELESTIA_NODE_AUTH_TOKEN,
+})
+```
+
+## API
+
+### `DALayer` (interface) and `DACommitment`
+
+```ts
+interface DALayer {
+  readonly name: string
+  submit(data: Uint8Array): Promise<DACommitment>
+  retrieve(commitment: DACommitment): Promise<Uint8Array>
+  verify(commitment: DACommitment): Promise<boolean>
+}
+```
+
+Implement this to add your own backend; consumers only see `DALayer`.
+
+### `LocalDA`
+
+In-memory, content-addressed blob store. `retrieve()` throws for unknown hashes; `verify()` returns `false` instead. Extras for tests: `nextBlock()` advances the reported height and resets the index, `size` counts stored blobs, `clear()` wipes everything. Resubmitting identical bytes reuses the same slot (content addressing).
+
+### `CelestiaDA` / `CelestiaDAOptions`
+
+Client for the Celestia Node REST API (`submit_pfb`, `namespaced_data`). `submit()` posts to your namespace and returns the inclusion height; `retrieve()` scans the namespace at that height for a blob matching the commitment hash; `verify()` is retrieve-and-rehash (network errors ⇒ `false`, not an exception). Options: `namespace` (required), `endpoint`, `authToken`.
+
+### `EthBlobDA` / `EthBlobDAOptions`
+
+The stub. Options (`rpcUrl`, `beaconUrl`, `chainId`) are accepted and stored; `submit`/`retrieve`/`verify` throw with step-by-step implementation requirements. Read the source of `eth-blobs.ts` for a complete viem-based sketch.
+
+### `encode(data)` / `decode(data)`
+
+3-byte magic header (`RJC` compressed / `RJR` raw) + payload. Compression is used only when fflate is available **and** actually shrinks the payload. `decode()` throws on missing/unknown magic and on compressed data without fflate.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-da`](https://www.npmjs.com/package/raijin-da): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).
 
-Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The underlying publish-workflow bug is fixed for good as part of this migration (`.github/workflows/publish.yml` now uses `pnpm publish`). See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
+Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The `workspace:*` publish bug can no longer recur: the monorepo has since converted to npm workspaces with real semver ranges, and releases go out via `npm publish --workspaces`. See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
 
 ## License
 

--- a/packages/da/README.md
+++ b/packages/da/README.md
@@ -82,6 +82,20 @@ The stub. Options (`rpcUrl`, `beaconUrl`, `chainId`) are accepted and stored; `s
 
 3-byte magic header (`RJC` compressed / `RJR` raw) + payload. Compression is used only when fflate is available **and** actually shrinks the payload. `decode()` throws on missing/unknown magic and on compressed data without fflate.
 
+## Wiring DA into a validator
+
+`ValidatorNode` (in `@johnhenry/raijin-validator`) does not post blocks to a DA layer yet — the pipeline is yours to call, and the natural place is a block-finalization handler:
+
+```js
+node.onBlockFinalized(async (block) => {
+  const bytes = serializeBlock(block)          // your serialization
+  const commitment = await da.submit(await encode(bytes))
+  await commitmentStore.save(block.header.number, commitment)
+})
+```
+
+Keep the commitment next to the block number; that pair is what a later reader needs to `retrieve()` and `verify()`. And remember the scoping above — storing the commitment proves nothing by itself; verification happens at read time, against whatever the backend still serves.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-da`](https://www.npmjs.com/package/raijin-da): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).

--- a/packages/mempool/README.md
+++ b/packages/mempool/README.md
@@ -2,17 +2,91 @@
 
 Transaction mempool with fee-based ordering and eviction for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
+Accepts transactions, verifies signatures through an injected verifier, deduplicates by sender+nonce, orders by fee for block building, evicts the lowest-fee transaction when full, and optionally gossips accepted transactions to peers.
+
 ## Install
 
 ```bash
 npm install @johnhenry/raijin-mempool
 ```
 
+## The fee convention — read this first
+
+`defaultFeeExtractor` reads the **first 8 bytes of `tx.data` as a big-endian uint64 fee** (shorter data ⇒ fee `0n`). Two traps hide in that sentence:
+
+1. **It collides with the state machine's convention.** `@johnhenry/raijin-core`'s `StateMachine` treats `tx.data[0]` as the transaction *type*. A `data` layout can't serve both defaults at once — if your transactions carry typed data, supply your own `FeeExtractor` (e.g. `(tx) => tx.value` for tip-style fees).
+2. **The config doc-comment in older builds says the default is `tx.value`. It is not.** The default is the 8-byte data prefix; verify with `defaultFeeExtractor(tx)` if in doubt.
+
+Also note: this package is standalone. `@johnhenry/raijin-validator` ships its **own, different `Mempool`** (FIFO, no verification, throws when full) and uses that one internally — see "Which mempool am I holding?" below.
+
+## Quick start
+
+```js
+import { Mempool, defaultFeeExtractor } from '@johnhenry/raijin-mempool'
+
+const pool = new Mempool({
+  verifier: async (tx) => myVerifySignature(tx), // required
+  maxSize: 4096,                                 // default 4096
+  feeExtractor: (tx) => tx.value,                // optional — see trap above
+  gossip: { broadcast: (tx) => channel.send(tx) }, // optional
+})
+
+pool.onDropped((tx, reason) => console.log('dropped:', reason))
+// reasons: 'duplicate' | 'invalid-signature' | 'pool-full' | 'evicted'
+
+await pool.submit(tx)          // true if accepted (also gossiped), false if dropped
+const forBlock = pool.pendingForProposer(100) // top-100 by fee
+```
+
+## API
+
+### `Mempool`
+
+`new Mempool(config: MempoolConfig)` — `config.verifier` is required; `maxSize`, `feeExtractor`, `gossip` optional.
+
+| Member | Purpose |
+| --- | --- |
+| `submit(tx): Promise<boolean>` | Dedup (sender+nonce) → verify signature → evict-or-reject if full → accept + gossip. |
+| `remove(tx): boolean` / `removeBatch(txs): number` | Drop by sender+nonce identity (e.g. after block inclusion). |
+| `pending(): Transaction[]` | All transactions, fee-descending, nonce-ascending on ties. |
+| `pendingForProposer(limit?): Transaction[]` | The same ordering, truncated to `limit`. |
+| `has(tx)` / `hasNonce(sender, nonce)` | Membership checks by sender+nonce. |
+| `size` | Current count. |
+| `onAccepted(handler)` / `onDropped(handler)` | Event hooks; `onDropped` receives a reason string. |
+
+Eviction rule: when the pool is full, an incoming transaction must have a **strictly higher** fee than the current lowest to displace it. Equal fee ⇒ dropped as `'pool-full'`. The displaced transaction is emitted as `'evicted'`.
+
+Identity is sender+nonce, not content: a second transaction from the same sender with the same nonce is a `'duplicate'` even if its fee is higher — there is no replace-by-fee.
+
+### `orderByFee(txs, feeExtractor): Transaction[]`
+
+Pure sorting helper (fee descending, nonce ascending on ties). Returns a new array; usable without a `Mempool`.
+
+### `defaultFeeExtractor(tx): bigint`
+
+The 8-byte big-endian data prefix described above.
+
+### Types
+
+`MempoolConfig`, `FeeExtractor` (`(tx) => bigint`), `TransactionVerifier` (`(tx) => Promise<boolean>`), `GossipTransport` (`{ broadcast(tx) }`), `MempoolEvents`.
+
+## Which mempool am I holding?
+
+| | `@johnhenry/raijin-mempool` `Mempool` | `@johnhenry/raijin-validator` `Mempool` |
+| --- | --- | --- |
+| Ordering | fee-descending | FIFO |
+| Signature check | yes, injected verifier | none |
+| Full pool | evict lowest / reject | `throw new Error('Mempool full')` |
+| Submit API | `submit(tx) → boolean` | `add(tx) → tx-hash hex` |
+| Used by `ValidatorNode` | no | yes |
+
+They share a name and nothing else. If you want fee ordering inside a validator today, you wire it yourself (the fee-ordered pool is not yet integrated into `ValidatorNode`).
+
 ## Provenance
 
 Previously published unscoped as [`raijin-mempool`](https://www.npmjs.com/package/raijin-mempool): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).
 
-Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The underlying publish-workflow bug is fixed for good as part of this migration (`.github/workflows/publish.yml` now uses `pnpm publish`). See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
+Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The `workspace:*` publish bug can no longer recur: the monorepo has since converted to npm workspaces with real semver ranges, and releases go out via `npm publish --workspaces`. See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
 
 ## License
 

--- a/packages/mempool/README.md
+++ b/packages/mempool/README.md
@@ -70,6 +70,19 @@ The 8-byte big-endian data prefix described above.
 
 `MempoolConfig`, `FeeExtractor` (`(tx) => bigint`), `TransactionVerifier` (`(tx) => Promise<boolean>`), `GossipTransport` (`{ broadcast(tx) }`), `MempoolEvents`.
 
+## Using it as a block builder's source
+
+The intended consumption pattern — take the top of the pool, build, then prune exactly what was included:
+
+```js
+const txs = pool.pendingForProposer(maxTxPerBlock) // top-N by fee
+const block = await buildBlock(txs)                // your producer
+// …after the block finalizes:
+pool.removeBatch(block.transactions)               // prune by sender+nonce
+```
+
+`pending()` returns a fresh array each call, so it's safe to build from while `submit()`s keep arriving — but the pool contents can change between `pendingForProposer()` and `removeBatch()`, which is fine: `removeBatch` returns how many were actually removed, and transactions that arrived meanwhile simply wait for the next block.
+
 ## Which mempool am I holding?
 
 | | `@johnhenry/raijin-mempool` `Mempool` | `@johnhenry/raijin-validator` `Mempool` |

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -80,6 +80,22 @@ interface ClientTransport {
 
 For tests and demos, back it directly with a `ValidatorNode`: `getAccount` → `node.stateMachine.getAccount`, `submitTransaction` → `node.submitTransaction` + match the receipt by `hash(encodeTx(tx))` in `onBlockFinalized`.
 
+## Correlating submissions with receipts
+
+Receipts identify transactions by `txHash = hash(encodeTx(tx))` — the hash of the *unsigned* canonical encoding (the validator's mempool separately keys by the signed encoding; don't mix them up). To match your own submission inside a block-finalized callback:
+
+```js
+import { hash, encodeTx, equal } from '@johnhenry/raijin-core'
+
+const want = await hash(encodeTx(tx))
+node.onBlockFinalized((_block, receipts) => {
+  const mine = receipts.find((r) => equal(r.txHash, want))
+  if (mine) console.log(mine.status, mine.revertReason ?? '')
+})
+```
+
+This is exactly how the in-process `ClientTransport` in `examples/07-sdk-end-to-end.mjs` implements `submitTransaction()`'s wait-for-receipt semantics.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-sdk`](https://www.npmjs.com/package/raijin-sdk): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -2,17 +2,89 @@
 
 Developer-facing client API for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — submit transactions and query state from a browser-native validator mesh.
 
+Two pieces: `Wallet` (Ed25519 key management + transaction building/signing over Web Crypto) and `RaijinClient` (submit/query/subscribe through an injected `ClientTransport`). The SDK deliberately does not know how bytes reach a validator — you implement `ClientTransport` over HTTP, WebRTC, a Worker port, or an in-process node.
+
 ## Install
 
 ```bash
 npm install @johnhenry/raijin-sdk
 ```
 
+## Things to know first
+
+- **`Wallet` needs Web Crypto Ed25519.** Node 20+ and current browsers have it; older environments throw at `Wallet.generate()`. The repo targets Node ≥ 24.
+- **Signatures cover `encodeTx(tx)` — everything except the signature itself.** Mutate any field after `buildTx()` and verification fails (that's the point). Validators hash the same bytes for the receipt `txHash`, so `hash(encodeTx(tx))` is how you match your transaction to its receipt.
+- **Nonce management is yours.** `buildTx()` takes an explicit `nonce`; fetch the account first (`(await client.getAccount(wallet.publicKey)).nonce`) or track it locally. A wrong nonce becomes a `revert` receipt, not an error at submit time.
+- **`chainId` defaults to `1n`** and exists to prevent cross-chain replay; the reference state machine does not yet enforce it.
+
+## Quick start
+
+```js
+import { RaijinClient, Wallet } from '@johnhenry/raijin-sdk'
+
+const wallet = await Wallet.generate()
+
+const client = new RaijinClient(transport) // your ClientTransport implementation
+
+const account = await client.getAccount(wallet.publicKey)
+const tx = await wallet.buildTx({
+  to: recipientPublicKey,     // Uint8Array(32), or null for system ops
+  value: 250n,
+  nonce: account.nonce,
+})
+
+const receipt = await client.submitTransaction(tx)  // { txHash, status, revertReason?, index }
+const unsubscribe = client.subscribe((block) => console.log('block', block.header.number))
+```
+
+A complete end-to-end run — real Ed25519 verification against an in-process `ValidatorNode`, including a tampered-transaction revert — is in [`examples/07-sdk-end-to-end.mjs`](https://github.com/johnhenry/raijin/blob/main/examples/07-sdk-end-to-end.mjs).
+
+## API
+
+### `Wallet` (implements `TransactionSigner`)
+
+| Member | Purpose |
+| --- | --- |
+| `static generate(): Promise<Wallet>` | New Ed25519 keypair via `crypto.subtle.generateKey`. |
+| `static fromKey(pkcs8: Uint8Array): Promise<Wallet>` | Import a private key (PKCS8); the public key is derived from it. |
+| `publicKey: Uint8Array` | 32-byte raw public key — this is your address. |
+| `sign(message): Promise<Uint8Array>` | Raw Ed25519 signature (64 bytes, deterministic). |
+| `buildTx(opts: BuildTxOptions): Promise<Transaction>` | Assembles `{ from: publicKey, to, value, nonce, data?, chainId? }` and signs it. |
+| `exportPrivateKey(): Promise<Uint8Array>` | PKCS8 bytes for storage; round-trips through `fromKey()`. |
+
+`BuildTxOptions`: `{ to, value, nonce, data?, chainId? }` — `data` defaults to empty (which the state machine treats as a `Transfer`; set `data[0]` to a `TransactionType` byte for anything else).
+
+### `RaijinClient`
+
+`new RaijinClient(transport: ClientTransport)`
+
+| Member | Purpose |
+| --- | --- |
+| `submitTransaction(tx): Promise<TransactionReceipt>` | Send and wait for the execution receipt. |
+| `getAccount(address): Promise<Account>` | `{ balance, nonce, reputation }`; unknown addresses are zero accounts. |
+| `getBlock(number): Promise<Block \| null>` | By height. |
+| `subscribe(handler): () => void` | New finalized blocks; returns the unsubscribe function. |
+
+The client is a thin, typed pass-through — all reliability semantics (timeouts, retries, which validator answers queries) live in your transport.
+
+### `ClientTransport` (interface)
+
+```ts
+interface ClientTransport {
+  submitTransaction(tx: Transaction): Promise<TransactionReceipt>
+  getAccount(address: Uint8Array): Promise<Account>
+  getBlock(number: bigint): Promise<Block | null>
+  onBlock(handler: (block: Block) => void): () => void
+}
+```
+
+For tests and demos, back it directly with a `ValidatorNode`: `getAccount` → `node.stateMachine.getAccount`, `submitTransaction` → `node.submitTransaction` + match the receipt by `hash(encodeTx(tx))` in `onBlockFinalized`.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-sdk`](https://www.npmjs.com/package/raijin-sdk): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).
 
-Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The underlying publish-workflow bug is fixed for good as part of this migration (`.github/workflows/publish.yml` now uses `pnpm publish`). See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
+Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The `workspace:*` publish bug can no longer recur: the monorepo has since converted to npm workspaces with real semver ranges, and releases go out via `npm publish --workspaces`. See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
 
 ## License
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -70,6 +70,16 @@ Config: `proposer` (pubkey), `consensus`, `mempool`, optional `maxTxPerBlock` (d
 
 `new Mempool(maxSize = 4096)` — `add(tx): Promise<string>` (throws when full), `pending(limit?)` (FIFO), `remove(hashHex)`, `removeBatch(txs)`, `clear()`, `size`. Keyed by hash of the signed encoding, so the same signed tx submitted twice occupies one slot.
 
+## Running more than one node
+
+Everything above scales to a real mesh, but three things change:
+
+1. **The transport becomes real.** Every node's `transport.broadcast`/`send` must reach every other validator, and `onMessage` must report the sender's actual public key as `from` — consensus trusts that value, so an unauthenticated transport means any peer can impersonate any validator. If your wire format is JSON, consensus messages carry `bigint`s and `Uint8Array`s; you need a replacer/reviver pair (`packages/consensus/test/helpers.ts` has a working one).
+2. **`validators` must be byte-identical on every node** — same keys, same order. Leader election is positional (`view % n`), so a different ordering means nodes disagree about who may propose and nothing ever finalizes, with no error to tell you why.
+3. **Quorum math starts to matter.** At n = 4 you tolerate one faulty node (quorum 3); below that, quorum is 1 and any single node can finalize alone. Pick n = 3f + 1 for the f you actually need.
+
+Multi-node scenarios — leader crashes, partitions, membership churn — are exercised by the repo's internal `raijin-test-harness` package (`TestOrchestrator` + `PartitionableNetwork` + invariant checkers) rather than examples, because they're timing-sensitive by nature. Read the harness tests for working multi-node wiring.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-validator`](https://www.npmjs.com/package/raijin-validator): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -2,17 +2,79 @@
 
 Composition root wiring core, consensus, and mempool into a runnable validator node for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
+`ValidatorNode` assembles a `StateMachine`, a `PBFTConsensus` engine, a FIFO `Mempool`, and a `BlockProducer`, then runs the loop: accept transactions → (if leader) build a block on the block timer → propose → finalize → apply state → prune mempool. You inject identity (keys + sign/verify), a network transport, a timer, and a state store — the node is transport-, storage-, and identity-agnostic.
+
 ## Install
 
 ```bash
 npm install @johnhenry/raijin-validator
 ```
 
+## Traps first
+
+- **This package's `Mempool` is not `@johnhenry/raijin-mempool`.** It's a separate, simpler class: FIFO order (no fee ordering), **no signature verification**, and `add()` **throws** `'Mempool full'` at capacity instead of evicting. The fee-ordered, verifying pool in `@johnhenry/raijin-mempool` is not wired into `ValidatorNode` today.
+- **`submitTransaction()` accepts anything.** Invalid signatures, bad nonces, and overspends are only caught when the block executes — they become `revert` receipts, but they still occupied mempool and block space on the way.
+- **`validators` must include this node's own public key**, or `isLeader` is never true and (with `n = 1`) nothing ever finalizes. All nodes must pass the same keys in the same order.
+- **Block headers commit to transactions, not to state.** `BlockProducer` fills `txRoot` from the transactions but leaves `stateRoot`/`receiptRoot` zeroed ("filled after execution" — currently never filled), and `advance()` uses the previous header's `stateRoot` field as `parentHash`. Consensus therefore agrees on *transaction ordering*, and state agreement is by construction (same deterministic state machine), not by header commitment.
+- **Quorum below 4 validators is 1.** See `@johnhenry/raijin-consensus` — a single-validator "network" finalizes its own blocks instantly, which is exactly what the quick start below exploits.
+
+## Quick start — a one-validator chain
+
+```js
+import { InMemoryStateStore } from '@johnhenry/raijin-core'
+import { ValidatorNode } from '@johnhenry/raijin-validator'
+
+const node = new ValidatorNode({
+  identity: { publicKey, sign, verify },   // your keys; verify checks tx signatures
+  transport: { broadcast() {}, send() {}, onMessage() {} }, // single node: no peers
+  timer: { set: (ms, cb) => setTimeout(cb, ms), clear: clearTimeout },
+  store: new InMemoryStateStore(),
+  validators: [publicKey],                  // include self!
+  blockTime: 2000,
+})
+
+node.onBlockFinalized((block, receipts) => console.log('block', block.header.number))
+node.start()
+
+const txHashHex = await node.submitTransaction(signedTx)
+```
+
+With one validator the node is always leader: the block timer fires, `BlockProducer` drains the mempool, `propose()` runs, and quorum (1) finalizes immediately. A runnable version, including genesis funding, is in [`examples/06-validator-lifecycle.mjs`](https://github.com/johnhenry/raijin/blob/main/examples/06-validator-lifecycle.mjs).
+
+## API
+
+### `ValidatorNode` / `ValidatorNodeConfig`
+
+Config: `identity` (`{ publicKey, sign, verify }`), `transport` (`NetworkTransport`), `timer` (`ConsensusTimer`), `store` (`StateStore`), plus optional `blockTime` (ms, default 2000), `validators` (default `[]` — see trap above), `maxTxPerBlock` (default 100), `maxMempoolSize` (default 4096).
+
+| Member | Purpose |
+| --- | --- |
+| `start()` / `stop()` | Start/stop consensus and the block-production timer loop. Idempotent. |
+| `submitTransaction(tx): Promise<string>` | Adds to the FIFO mempool; resolves to the tx hash hex (hash of the *signed* encoding). Throws if the mempool is full. |
+| `onBlockFinalized(handler)` | `(block, receipts) => void` after every finalized block. |
+| `latestBlock` | Most recently finalized `Block`, or `null`. |
+| `running` | Boolean. |
+| `consensus` / `mempool` / `stateMachine` / `blockProducer` | The wired sub-components, exposed for advanced use (e.g. `node.stateMachine.getAccount(addr)`). |
+
+Block-production errors inside the timer loop are swallowed by design (not being leader or having an empty mempool is normal); drive `node.blockProducer.produceBlock()` manually if you need the error.
+
+### `BlockProducer` / `BlockProducerConfig`
+
+Config: `proposer` (pubkey), `consensus`, `mempool`, optional `maxTxPerBlock` (default 100).
+
+- `produceBlock(): Promise<Block | null>` — returns `null` when not leader or mempool empty; otherwise builds a block (Merkle `txRoot` over signed-tx hashes) and calls `consensus.propose()`.
+- `advance(block)` — called after finalization to bump `nextBlockNumber` and carry the parent linkage.
+- `nextBlockNumber: bigint` — getter.
+
+### `Mempool` (the FIFO one)
+
+`new Mempool(maxSize = 4096)` — `add(tx): Promise<string>` (throws when full), `pending(limit?)` (FIFO), `remove(hashHex)`, `removeBatch(txs)`, `clear()`, `size`. Keyed by hash of the signed encoding, so the same signed tx submitted twice occupies one slot.
+
 ## Provenance
 
 Previously published unscoped as [`raijin-validator`](https://www.npmjs.com/package/raijin-validator): `0.0.1` (initial release, 2026-03-15), then `0.0.2` (2026-07-16 — published with a broken build, because the release workflow used plain `npm publish`, which does not rewrite `workspace:*` internal dependency specifiers into real resolved versions; that tarball was unpublished), then `0.0.3` (2026-07-16, same day — republished correctly via `pnpm publish`, the last unscoped version, live until this move).
 
-Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The underlying publish-workflow bug is fixed for good as part of this migration (`.github/workflows/publish.yml` now uses `pnpm publish`). See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
+Moved into the `@johnhenry` npm scope and restarted at `0.0.0` — no functional changes in the move. The `workspace:*` publish bug can no longer recur: the monorepo has since converted to npm workspaces with real semver ranges, and releases go out via `npm publish --workspaces`. See the [root CHANGELOG](https://github.com/johnhenry/raijin/blob/main/CHANGELOG.md) for the full project history.
 
 ## License
 


### PR DESCRIPTION
## What

The six per-package READMEs were 19–21-line provenance stubs with zero API content. This PR turns them into real documentation and backs the claims with runnable code.

### READMEs (all six packages)
Full export surface with signatures, quick starts, and the sharp edges documented **first**, all verified against source:
- PBFT quorum is `2f+1` with `f = floor((n-1)/3)` — **quorum = 1 for n ≤ 3**; no BFT below 4 validators
- `@johnhenry/raijin-mempool` and `@johnhenry/raijin-validator` export two **unrelated `Mempool` classes** (fee-ordered/verifying vs FIFO/unverified); `ValidatorNode` uses the FIFO one
- `defaultFeeExtractor` reads the first 8 bytes of `tx.data` as the fee, colliding with the state machine's `data[0]`-is-tx-type convention (and contradicting the config doc-comment)
- `DACommitment.verify()` proves content, not inclusion; `EthBlobDA` is a stub that throws; `encode()` output depends on optional fflate
- `BlockProducer` leaves `stateRoot`/`receiptRoot` zeroed — consensus commits to tx ordering, not state
- Provenance notes kept verbatim, with the stale "publish.yml now uses pnpm publish" line updated for the npm-workspaces conversion

### Root README
New section documenting `raijin-test-harness` (orchestrator, partitionable network, invariant checkers, workloads) and why it stays unpublished.

### Examples (new)
Seven numbered, self-checking walkthroughs (`examples/01`–`07`): hashing/Merkle, state machine + reverts, mempool ordering/eviction, LocalDA + encode/decode, a single-validator PBFT round, the ValidatorNode lifecycle, and an SDK end-to-end run with real Ed25519 verification. Root scripts `example:01`–`07` + an `examples` loop, wired into CI as a smoke step. **All examples are single-node by design** — multi-node timing scenarios stay in the test harness and are excluded from the smoke step (documented in `examples/README.md`).

### CHANGELOG
Entry added for the docs/examples work.

## Gate

- `npm run build` ✅  `npm run typecheck` ✅
- 123/123 deterministic tests across the six publishable packages ✅ (harness's 11 known-flaky multi-node tests intentionally not gated)
- `npm run examples`: 7/7 ✅

No library source changes.