### PR TITLE
docs: link the docs-site section from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Raijin
 
+Full documentation: [opensource.johnhenry.me/raijin](https://opensource.johnhenry.me/raijin/)
+
 A browser-native mesh rollup framework. Build sovereign rollups where
 the users ARE the validators.
 


### PR DESCRIPTION
Cross-pollination pass (W-X) of the @johnhenry docs overhaul: every repo README links its section on opensource.johnhenry.me, matching the family convention (spintax, temporals, semantic-chunker, math, math-plus, optical-artifact-transport already do). One line, no other changes.