### PR TITLE
Bind vote signatures to phase/view/sequence, fix the quorum, and stop leaking the DA auth token

### DIFF
--- a/examples/01-hashing-merkle.mjs
+++ b/examples/01-hashing-merkle.mjs
@@ -21,7 +21,7 @@ console.log('hashString(raijin) =', toHex(strDigest))
 const leaves = [
   await hashString('tx-a'),
   await hashString('tx-b'),
-  await hashString('tx-c'), // odd count — last leaf is duplicated for padding
+  await hashString('tx-c'), // odd count — the last node is promoted, not duplicated
 ]
 const root = await merkleRoot(leaves)
 console.log('merkleRoot(3)      =', toHex(root))
@@ -30,9 +30,16 @@ console.log('merkleRoot(3)      =', toHex(root))
 const swapped = await merkleRoot([leaves[1], leaves[0], leaves[2]])
 assert.ok(!equal(root, swapped), 'reordering leaves must change the root')
 
-// Edge cases: single leaf is returned as-is; empty input is hash of empty bytes
-assert.ok(equal(await merkleRoot([leaves[0]]), leaves[0]))
+// Edge cases: a single leaf is still hashed (a leaf is never itself a root),
+// and empty input has its own root
+assert.ok(!equal(await merkleRoot([leaves[0]]), leaves[0]))
+assert.equal((await merkleRoot([leaves[0]])).length, 32)
 assert.equal((await merkleRoot([])).length, 32)
+
+// An odd leaf count is padded by promoting the last node, not by duplicating
+// the last leaf — so a duplicated final transaction is a different root.
+assert.ok(!equal(root, await merkleRoot([...leaves, leaves[2]])),
+  'duplicating the last leaf must change the root')
 
 // Hex round-trip
 const hex = toHex(root)

--- a/examples/07-sdk-end-to-end.mjs
+++ b/examples/07-sdk-end-to-end.mjs
@@ -97,7 +97,7 @@ const unsub = client.subscribe((block) =>
   console.log('new block:', block.header.number, '| txs:', block.transactions.length))
 
 // Build and sign a transfer — Wallet signs the canonical tx encoding
-const tx = await userWallet.buildTx({ to: merchant, value: 250n, nonce: 0n })
+const tx = await userWallet.buildTx({ to: merchant, value: 250n, nonce: 0n, chainId: 1n })
 assert.equal(tx.signature.length, 64)
 
 const receipt = await client.submitTransaction(tx)
@@ -120,7 +120,7 @@ assert.equal(await client.getBlock(99n), null)
 // (@johnhenry/raijin-mempool) verifies signatures at submission time —
 // stronger than catching it later at execution: the bad tx never makes
 // it into a block at all.
-const evil = await userWallet.buildTx({ to: merchant, value: 1n, nonce: 1n })
+const evil = await userWallet.buildTx({ to: merchant, value: 1n, nonce: 1n, chainId: 1n })
 evil.value = 999n // mutate after signing
 await assert.rejects(() => client.submitTransaction(evil), /rejected by mempool/)
 console.log('tampered tx: rejected by mempool before ever reaching a block')

--- a/packages/consensus/src/index.ts
+++ b/packages/consensus/src/index.ts
@@ -25,3 +25,6 @@ export type {
 } from './types.js'
 
 export { PBFTPhase } from './types.js'
+
+export { voteDigest, NO_BLOCK_DIGEST } from './vote.js'
+export type { VotePhase } from './vote.js'

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -298,6 +298,12 @@ export class PBFTConsensus {
   }
 
   async #handleViewChange(from: Uint8Array, msg: ViewChangeMessage): Promise<void> {
+    // A view change only ever moves forward. A VIEW-CHANGE signature covers
+    // (newView, sequence) and nothing time-bound, so a recorded quorum stays
+    // valid forever; without this check, replaying one rewinds `#view` and
+    // clears every in-flight round, indefinitely, with no keys required.
+    if (msg.newView <= this.#view) return
+
     if (!(await this.#verifyVote('view-change', msg.newView, msg.sequence, NO_BLOCK_DIGEST, msg.signature, from))) return
 
     const key = msg.newView.toString()
@@ -325,6 +331,10 @@ export class PBFTConsensus {
    * validator could force every other node to jump views at will.
    */
   async #handleNewView(_from: Uint8Array, msg: NewViewMessage): Promise<void> {
+    // Forward only — see #handleViewChange. A NEW-VIEW is the cheapest replay:
+    // one message carrying a recorded quorum.
+    if (msg.view <= this.#view) return
+
     const seenSenders = new Set<string>()
 
     for (const vc of msg.viewChanges) {
@@ -474,6 +484,7 @@ export class PBFTConsensus {
    * tracked as follow-up work.
    */
   #doViewChange(newView: bigint): void {
+    if (newView <= this.#view) return
     this.#view = newView
     this.#phase = PBFTPhase.Idle
     this.#pendingBlock = null

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -15,6 +15,7 @@
 import type { Block, StateMachine, TransactionReceipt, SignatureVerifier } from '@johnhenry/raijin-core'
 import { hash, merkleRoot, encodeReceipt, equal, toHex } from '@johnhenry/raijin-core'
 import { ValidatorSet } from './validator-set.js'
+import { voteDigest, NO_BLOCK_DIGEST, type VotePhase } from './vote.js'
 import type {
   NetworkTransport,
   ConsensusTimer,
@@ -47,9 +48,13 @@ export interface PBFTConfig {
   sign: (message: Uint8Array) => Promise<Uint8Array>
   /**
    * Verify a signature against a message and the claimed signer's public
-   * key. Used to authenticate PREPARE, COMMIT, and VIEW-CHANGE votes before
-   * they're counted toward quorum — without this, any peer that can reach
+   * key. Used to authenticate PRE-PREPARE, PREPARE, COMMIT, and VIEW-CHANGE
+   * votes before they're acted on — without this, any peer that can reach
    * `#handleMessage` could forge votes on behalf of any validator.
+   *
+   * Every vote is signed over a domain-separated payload (see `voteDigest`)
+   * that names the phase, the view and the sequence, so no signature is
+   * reusable in another phase or another round.
    */
   verify: SignatureVerifier
 }
@@ -149,18 +154,21 @@ export class PBFTConsensus {
     this.#sequence++
     this.#phase = PBFTPhase.PrePrepared
 
-    // Broadcast PRE-PREPARE
+    // Broadcast PRE-PREPARE, signed so that acceptance does not rest on the
+    // transport's `from` alone.
     const msg: PrePrepareMessage = {
       type: 'pre-prepare',
       view: this.#view,
       sequence: this.#sequence,
       block,
       digest,
+      from: this.#identity,
+      signature: await this.#signVote('pre-prepare', this.#view, this.#sequence, digest),
     }
     this.#transport.broadcast(msg)
 
     // Leader also sends PREPARE so other peers can count it
-    const prepareSignature = await this.#sign(digest)
+    const prepareSignature = await this.#signVote('prepare', this.#view, this.#sequence, digest)
     const prepare: PrepareMessage = {
       type: 'prepare',
       view: this.#view,
@@ -237,6 +245,10 @@ export class PBFTConsensus {
     const digest = await hash(blockBytes)
     if (!equal(digest, msg.digest)) return
 
+    // Verify the leader actually signed this proposal. `from` comes from the
+    // transport; the signature is what makes it mean something.
+    if (!(await this.#verifyVote('pre-prepare', msg.view, msg.sequence, digest, msg.signature, from))) return
+
     // Partial view-change safety mitigation: if this sequence was already
     // validly prepared (2f+1 PREPARE votes) at some prior view, refuse to
     // accept a *different* block for the same sequence. We can't yet
@@ -252,7 +264,7 @@ export class PBFTConsensus {
     this.#phase = PBFTPhase.PrePrepared
 
     // Send PREPARE
-    const signature = await this.#sign(digest)
+    const signature = await this.#signVote('prepare', this.#view, this.#sequence, digest)
     const prepare: PrepareMessage = {
       type: 'prepare',
       view: this.#view,
@@ -271,8 +283,7 @@ export class PBFTConsensus {
     if (msg.view !== this.#view) return
     if (msg.sequence !== this.#sequence) return
 
-    const valid = await this.#verify.verify(msg.digest, msg.signature, from)
-    if (!valid) return
+    if (!(await this.#verifyVote('prepare', msg.view, msg.sequence, msg.digest, msg.signature, from))) return
 
     await this.#addPrepare(msg.digest, from)
   }
@@ -281,16 +292,13 @@ export class PBFTConsensus {
     if (msg.view !== this.#view) return
     if (msg.sequence !== this.#sequence) return
 
-    const valid = await this.#verify.verify(msg.digest, msg.signature, from)
-    if (!valid) return
+    if (!(await this.#verifyVote('commit', msg.view, msg.sequence, msg.digest, msg.signature, from))) return
 
     await this.#addCommit(msg.digest, from)
   }
 
   async #handleViewChange(from: Uint8Array, msg: ViewChangeMessage): Promise<void> {
-    const digest = this.#viewChangeDigestBytes(msg.newView, msg.sequence)
-    const valid = await this.#verify.verify(digest, msg.signature, from)
-    if (!valid) return
+    if (!(await this.#verifyVote('view-change', msg.newView, msg.sequence, NO_BLOCK_DIGEST, msg.signature, from))) return
 
     const key = msg.newView.toString()
     if (!this.#viewChanges.has(key)) {
@@ -326,9 +334,7 @@ export class PBFTConsensus {
       const hex = toHex(vc.from)
       if (seenSenders.has(hex)) continue // dedup by sender
 
-      const digest = this.#viewChangeDigestBytes(vc.newView, vc.sequence)
-      const valid = await this.#verify.verify(digest, vc.signature, vc.from)
-      if (!valid) continue
+      if (!(await this.#verifyVote('view-change', vc.newView, vc.sequence, NO_BLOCK_DIGEST, vc.signature, vc.from))) continue
 
       seenSenders.add(hex)
     }
@@ -363,7 +369,7 @@ export class PBFTConsensus {
     this.#preparedCert.set(this.#sequence.toString(), digest)
 
     // Sign the digest and send COMMIT
-    const signature = await this.#sign(digest)
+    const signature = await this.#signVote('commit', this.#view, this.#sequence, digest)
     const commit: CommitMessage = {
       type: 'commit',
       view: this.#view,
@@ -443,8 +449,7 @@ export class PBFTConsensus {
 
   async #requestViewChange(): Promise<void> {
     const newView = this.#view + 1n
-    const digest = this.#viewChangeDigestBytes(newView, this.#sequence)
-    const signature = await this.#sign(digest)
+    const signature = await this.#signVote('view-change', newView, this.#sequence, NO_BLOCK_DIGEST)
     const msg: ViewChangeMessage = {
       type: 'view-change',
       newView,
@@ -542,13 +547,25 @@ export class PBFTConsensus {
     return bytes
   }
 
-  /** Deterministic bytes identifying a (newView, sequence) pair — what VIEW-CHANGE signatures cover. */
-  #viewChangeDigestBytes(newView: bigint, sequence: bigint): Uint8Array {
-    const a = this.#bigintToBytes(newView)
-    const b = this.#bigintToBytes(sequence)
-    const result = new Uint8Array(a.length + b.length)
-    result.set(a, 0)
-    result.set(b, a.length)
-    return result
+  /** Sign one vote over its domain-separated payload (see `voteDigest`). */
+  async #signVote(
+    phase: VotePhase,
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+  ): Promise<Uint8Array> {
+    return this.#sign(await voteDigest(phase, view, sequence, digest))
+  }
+
+  /** Verify one vote's signature against the claimed signer. */
+  async #verifyVote(
+    phase: VotePhase,
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+    signature: Uint8Array,
+    signer: Uint8Array,
+  ): Promise<boolean> {
+    return this.#verify.verify(await voteDigest(phase, view, sequence, digest), signature, signer)
   }
 }

--- a/packages/consensus/src/types.ts
+++ b/packages/consensus/src/types.ts
@@ -40,6 +40,14 @@ export interface PrePrepareMessage {
   sequence: bigint
   block: Block
   digest: Uint8Array
+  /** The proposing leader's public key. */
+  from: Uint8Array
+  /** Signature over `voteDigest('pre-prepare', view, sequence, digest)`, by
+   *  `from`. Verified before the proposal is accepted — without it, a proposal
+   *  is authenticated only by whatever `from` the transport supplies, so any
+   *  transport that does not itself authenticate peers (a relay, a gossip hub,
+   *  a signalling server forwarding a self-declared id) could inject blocks. */
+  signature: Uint8Array
 }
 
 export interface PrepareMessage {
@@ -48,7 +56,10 @@ export interface PrepareMessage {
   sequence: bigint
   digest: Uint8Array
   from: Uint8Array
-  /** Signature over `digest`, by `from`. Verified before counting toward quorum. */
+  /** Signature over `voteDigest('prepare', view, sequence, digest)`, by `from`.
+   *  Verified before counting toward quorum. The phase tag, view and sequence
+   *  are inside the signed bytes so the vote cannot be replayed as a COMMIT,
+   *  or into another view or sequence. */
   signature: Uint8Array
 }
 
@@ -58,6 +69,7 @@ export interface CommitMessage {
   sequence: bigint
   digest: Uint8Array
   from: Uint8Array
+  /** Signature over `voteDigest('commit', view, sequence, digest)`, by `from`. */
   signature: Uint8Array
 }
 
@@ -66,8 +78,10 @@ export interface ViewChangeMessage {
   newView: bigint
   sequence: bigint
   from: Uint8Array
-  /** Signature over hash(newView, sequence), by `from`. Verified before
-   *  counting toward a NEW-VIEW quorum. */
+  /** Signature over `voteDigest('view-change', newView, sequence,
+   *  NO_BLOCK_DIGEST)`, by `from`. Verified before counting toward a NEW-VIEW
+   *  quorum. Replay of an old VIEW-CHANGE is stopped by the monotonic view
+   *  check in the handler, not by the signature. */
   signature: Uint8Array
 }
 

--- a/packages/consensus/src/validator-set.ts
+++ b/packages/consensus/src/validator-set.ts
@@ -54,13 +54,27 @@ export class ValidatorSet {
     return this.#validators[idx]
   }
 
-  /** Quorum size: 2f + 1 where n = 3f + 1. */
+  /**
+   * Quorum size: `n - f`, where `f = floor((n - 1) / 3)`.
+   *
+   * At the canonical PBFT sizes (`n = 3f + 1`: 1, 4, 7, 10, ...) this is
+   * exactly `2f + 1`. For every other `n` it is strictly larger, because
+   * `2f + 1` is only safe when `n = 3f + 1`.
+   *
+   * Safety needs any two quorums to share at least one honest node --
+   * `2q - n >= f + 1`. With `q = 2f + 1` that fails for every `n` that is not
+   * `3f + 1`, and at `n = 2` or `n = 3` it degenerates to `q = 1`: a single
+   * node reaching its own PREPARE and COMMIT quorum, finalizing blocks alone.
+   * With `q = n - f` it holds for all `n`.
+   *
+   *   n:  1  2  3  4  5  6  7  8  9 10
+   *   f:  0  0  0  1  1  1  2  2  2  3
+   *   q:  1  2  3  3  4  5  5  6  7  7
+   */
   quorumSize(): number {
     const n = this.#validators.length
     if (n === 0) return 0
-    // f = floor((n - 1) / 3)
-    const f = Math.floor((n - 1) / 3)
-    return 2 * f + 1
+    return n - this.maxFaults
   }
 
   /** Number of validators. */

--- a/packages/consensus/src/vote.ts
+++ b/packages/consensus/src/vote.ts
@@ -1,0 +1,70 @@
+/**
+ * Domain-separated payloads for PBFT vote signatures.
+ *
+ * Every signature a validator produces must be usable in exactly one place:
+ * one phase, one view, one sequence, one block. Signing a bare digest is not
+ * enough, and the failure is not subtle — if PREPARE and COMMIT both sign
+ * `digest`, then a PREPARE, which is broadcast to every peer, *is* a valid
+ * COMMIT from the same validator, and the commit phase stops proving anything.
+ * Likewise, a signature that does not cover `view`/`sequence` can be lifted
+ * into a later round unchanged.
+ */
+
+import { hash } from '@johnhenry/raijin-core'
+
+/** Which vote a signature authorizes. Part of the signed bytes. */
+export type VotePhase = 'pre-prepare' | 'prepare' | 'commit' | 'view-change'
+
+/** Versioned domain tag per phase. Changing a tag invalidates old signatures. */
+const DOMAIN_TAGS: Record<VotePhase, string> = {
+  'pre-prepare': 'raijin/pbft/v1/pre-prepare',
+  'prepare': 'raijin/pbft/v1/prepare',
+  'commit': 'raijin/pbft/v1/commit',
+  'view-change': 'raijin/pbft/v1/view-change',
+}
+
+const encoder = new TextEncoder()
+
+/** Big-endian 8-byte encoding of a bigint, matching the block-header codec. */
+function bigintToBytes(value: bigint): Uint8Array {
+  const hex = value.toString(16).padStart(16, '0')
+  const bytes = new Uint8Array(8)
+  for (let i = 0; i < 8; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/** A digest slot for votes that commit to no block (VIEW-CHANGE). */
+export const NO_BLOCK_DIGEST = new Uint8Array(32)
+
+/**
+ * The bytes a validator signs for one vote.
+ *
+ * `H(tag || 0x00 || view || sequence || digest)`. The `0x00` separator keeps
+ * the variable-length tag from running into the fixed-width fields, so no two
+ * distinct (phase, view, sequence, digest) tuples can produce the same input.
+ *
+ * Exported so that a transport, relay or test can construct and check a vote
+ * without re-deriving the layout — there is one definition, and this is it.
+ */
+export async function voteDigest(
+  phase: VotePhase,
+  view: bigint,
+  sequence: bigint,
+  digest: Uint8Array,
+): Promise<Uint8Array> {
+  const tag = encoder.encode(DOMAIN_TAGS[phase])
+  const viewBytes = bigintToBytes(view)
+  const seqBytes = bigintToBytes(sequence)
+
+  const payload = new Uint8Array(tag.length + 1 + viewBytes.length + seqBytes.length + digest.length)
+  let pos = 0
+  payload.set(tag, pos); pos += tag.length
+  payload[pos++] = 0x00
+  payload.set(viewBytes, pos); pos += viewBytes.length
+  payload.set(seqBytes, pos); pos += seqBytes.length
+  payload.set(digest, pos)
+
+  return hash(payload)
+}

--- a/packages/consensus/test/pbft.test.ts
+++ b/packages/consensus/test/pbft.test.ts
@@ -703,4 +703,58 @@ describe('PBFTConsensus', () => {
     })
   })
 
+  // VIEW-CHANGE signatures cover (newView, sequence) and nothing time-bound, so
+  // a recorded quorum stays valid forever. Only a monotonic check stops it.
+  // See issue #18.
+  describe('view changes only move forward', () => {
+    it('ignores a replayed VIEW-CHANGE quorum for a view already passed', async () => {
+      const p2 = createPeer(key2)
+      p2.consensus.start()
+
+      const recorded: ViewChangeMessage[] = []
+      for (const key of [key1, key3, key4]) {
+        recorded.push(await makeViewChange(key, 2n, 0n))
+      }
+      for (const vc of recorded) network.createTransport(vc.from).send(key2, vc)
+      await network.drainAll()
+      expect(p2.consensus.currentView).toBe(2n)
+
+      // Move on to view 5.
+      for (const key of [key1, key3, key4]) {
+        network.createTransport(key).send(key2, await makeViewChange(key, 5n, 0n))
+      }
+      await network.drainAll()
+      expect(p2.consensus.currentView).toBe(5n)
+
+      // Replay the recorded view-2 quorum. Signatures are still valid.
+      for (const vc of recorded) network.createTransport(vc.from).send(key2, { ...vc })
+      await network.drainAll()
+      expect(p2.consensus.currentView).toBe(5n)
+
+      p2.consensus.stop()
+    })
+
+    it('ignores a NEW-VIEW carrying a genuine quorum for a view already passed', async () => {
+      const p2 = createPeer(key2)
+      p2.consensus.start()
+
+      for (const key of [key1, key3, key4]) {
+        network.createTransport(key).send(key2, await makeViewChange(key, 4n, 0n))
+      }
+      await network.drainAll()
+      expect(p2.consensus.currentView).toBe(4n)
+
+      const stale: NewViewMessage = {
+        type: 'new-view',
+        view: 1n,
+        viewChanges: await Promise.all([key1, key3, key4].map(k => makeViewChange(k, 1n, 0n))),
+      }
+      network.createTransport(key1).send(key2, stale)
+      await network.drainAll()
+
+      expect(p2.consensus.currentView).toBe(4n)
+
+      p2.consensus.stop()
+    })
+  })
 })

--- a/packages/consensus/test/pbft.test.ts
+++ b/packages/consensus/test/pbft.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
 import { StateMachine, InMemoryStateStore, hash, type Block } from '@johnhenry/raijin-core'
-import { PBFTConsensus, ValidatorSet, PBFTPhase } from '../src/index.js'
+import { PBFTConsensus, ValidatorSet, PBFTPhase, voteDigest, NO_BLOCK_DIGEST } from '../src/index.js'
 import type { NewViewMessage, PrePrepareMessage, ViewChangeMessage } from '../src/types.js'
 import { MockNetwork, DeterministicNetwork, MockTimer, mockVerifier, mockSign, makeTestKey } from './helpers.js'
 
@@ -53,14 +53,50 @@ async function computeDigest(block: Block): Promise<Uint8Array> {
   return hash(result)
 }
 
-/** Mirrors PBFTConsensus#viewChangeDigestBytes (what VIEW-CHANGE signatures cover — signed directly, not pre-hashed). */
-async function computeViewChangeDigest(newView: bigint, sequence: bigint): Promise<Uint8Array> {
-  const a = bigintToBytes(newView)
-  const b = bigintToBytes(sequence)
-  const combined = new Uint8Array(a.length + b.length)
-  combined.set(a, 0)
-  combined.set(b, a.length)
-  return combined
+/** Sign one vote the way PBFTConsensus does: over the domain-separated
+ *  payload from `voteDigest`, not over the bare block digest. */
+async function signVote(
+  key: Uint8Array,
+  phase: 'pre-prepare' | 'prepare' | 'commit' | 'view-change',
+  view: bigint,
+  sequence: bigint,
+  digest: Uint8Array,
+): Promise<Uint8Array> {
+  return mockSign(key)(await voteDigest(phase, view, sequence, digest))
+}
+
+/** A validly-signed VIEW-CHANGE from `key`. */
+async function makeViewChange(
+  key: Uint8Array,
+  newView: bigint,
+  sequence: bigint,
+): Promise<ViewChangeMessage> {
+  return {
+    type: 'view-change',
+    newView,
+    sequence,
+    from: key,
+    signature: await signVote(key, 'view-change', newView, sequence, NO_BLOCK_DIGEST),
+  }
+}
+
+/** A validly-signed PRE-PREPARE from `key`. */
+async function makePrePrepare(
+  key: Uint8Array,
+  view: bigint,
+  sequence: bigint,
+  block: Block,
+  digest: Uint8Array,
+): Promise<PrePrepareMessage> {
+  return {
+    type: 'pre-prepare',
+    view,
+    sequence,
+    block,
+    digest,
+    from: key,
+    signature: await signVote(key, 'pre-prepare', view, sequence, digest),
+  }
 }
 
 describe('PBFTConsensus', () => {
@@ -293,11 +329,11 @@ describe('PBFTConsensus', () => {
       // Bring p1 to Prepared with two genuine PREPAREs (2 + self = 3 = quorum).
       network.createTransport(key2).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest, from: key2,
-        signature: await mockSign(key2)(digest),
+        signature: await signVote(key2, 'prepare', 0n, 1n, digest),
       })
       network.createTransport(key3).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest, from: key3,
-        signature: await mockSign(key3)(digest),
+        signature: await signVote(key3, 'prepare', 0n, 1n, digest),
       })
       await network.drainAll()
 
@@ -322,11 +358,11 @@ describe('PBFTConsensus', () => {
       // Now deliver two GENUINE commits — this is what should actually finalize it.
       network.createTransport(key2).send(key1, {
         type: 'commit', view: 0n, sequence: 1n, digest, from: key2,
-        signature: await mockSign(key2)(digest),
+        signature: await signVote(key2, 'commit', 0n, 1n, digest),
       })
       network.createTransport(key3).send(key1, {
         type: 'commit', view: 0n, sequence: 1n, digest, from: key3,
-        signature: await mockSign(key3)(digest),
+        signature: await signVote(key3, 'commit', 0n, 1n, digest),
       })
       await network.drainAll()
 
@@ -356,7 +392,7 @@ describe('PBFTConsensus', () => {
       // Genuine PREPARE from key2 (2/3).
       network.createTransport(key2).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest, from: key2,
-        signature: await mockSign(key2)(digest),
+        signature: await signVote(key2, 'prepare', 0n, 1n, digest),
       })
       await network.drainAll()
       expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared) // still not quorum
@@ -372,7 +408,7 @@ describe('PBFTConsensus', () => {
       // Genuine PREPARE from key3 — now 3/3, reaches quorum.
       network.createTransport(key3).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest, from: key3,
-        signature: await mockSign(key3)(digest),
+        signature: await signVote(key3, 'prepare', 0n, 1n, digest),
       })
       await network.drainAll()
       expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
@@ -388,10 +424,9 @@ describe('PBFTConsensus', () => {
 
       const newView = 1n
       const sequence = 0n
-      const digest = await computeViewChangeDigest(newView, sequence)
-      const signature = await mockSign(key3)(digest)
+      const vc = await makeViewChange(key3, newView, sequence)
 
-      const makeVc = (): ViewChangeMessage => ({ type: 'view-change', newView, sequence, from: key3, signature })
+      const makeVc = (): ViewChangeMessage => ({ ...vc })
 
       // The SAME sender's VIEW-CHANGE delivered 3 times must not fake a 3-of-4 quorum.
       network.createTransport(key3).send(key2, makeVc())
@@ -412,12 +447,9 @@ describe('PBFTConsensus', () => {
 
       const newView = 1n
       const sequence = 0n
-      const digest = await computeViewChangeDigest(newView, sequence)
 
       for (const key of [key1, key3, key4]) {
-        const signature = await mockSign(key)(digest)
-        const msg: ViewChangeMessage = { type: 'view-change', newView, sequence, from: key, signature }
-        network.createTransport(key).send(key2, msg)
+        network.createTransport(key).send(key2, await makeViewChange(key, newView, sequence))
       }
       await network.drainAll()
 
@@ -435,17 +467,13 @@ describe('PBFTConsensus', () => {
 
       const newView = 1n
       const sequence = 0n
-      const digest = await computeViewChangeDigest(newView, sequence)
-      const signature = await mockSign(key1)(digest)
+      const vc = await makeViewChange(key1, newView, sequence)
 
       // Only one distinct valid backer (need 3) — repeating it doesn't help.
       const badNewView: NewViewMessage = {
         type: 'new-view',
         view: newView,
-        viewChanges: [
-          { type: 'view-change', newView, sequence, from: key1, signature },
-          { type: 'view-change', newView, sequence, from: key1, signature },
-        ],
+        viewChanges: [{ ...vc }, { ...vc }],
       }
       network.createTransport(key3).send(key2, badNewView)
       await network.drainAll()
@@ -487,12 +515,10 @@ describe('PBFTConsensus', () => {
 
       const newView = 1n
       const sequence = 0n
-      const digest = await computeViewChangeDigest(newView, sequence)
 
       const viewChanges: ViewChangeMessage[] = []
       for (const key of [key1, key3, key4]) {
-        const signature = await mockSign(key)(digest)
-        viewChanges.push({ type: 'view-change', newView, sequence, from: key, signature })
+        viewChanges.push(await makeViewChange(key, newView, sequence))
       }
       const goodNewView: NewViewMessage = { type: 'new-view', view: newView, viewChanges }
       network.createTransport(key1).send(key2, goodNewView)
@@ -518,11 +544,11 @@ describe('PBFTConsensus', () => {
       // and has recorded a prepared certificate for sequence 1.
       network.createTransport(key2).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest: digestA, from: key2,
-        signature: await mockSign(key2)(digestA),
+        signature: await signVote(key2, 'prepare', 0n, 1n, digestA),
       })
       network.createTransport(key3).send(key1, {
         type: 'prepare', view: 0n, sequence: 1n, digest: digestA, from: key3,
-        signature: await mockSign(key3)(digestA),
+        signature: await signVote(key3, 'prepare', 0n, 1n, digestA),
       })
       await network.drainAll()
       expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
@@ -531,12 +557,8 @@ describe('PBFTConsensus', () => {
       // (key2, key3, key4 — distinct senders) BEFORE a COMMIT quorum is
       // reached, so blockA is prepared but never committed.
       const newView = 1n
-      const vcDigest = await computeViewChangeDigest(newView, 1n)
       for (const key of [key2, key3, key4]) {
-        const signature = await mockSign(key)(vcDigest)
-        network.createTransport(key).send(key1, {
-          type: 'view-change', newView, sequence: 1n, from: key, signature,
-        } satisfies ViewChangeMessage)
+        network.createTransport(key).send(key1, await makeViewChange(key, newView, 1n))
       }
       await network.drainAll()
 
@@ -548,9 +570,8 @@ describe('PBFTConsensus', () => {
       // since blockA was already validly prepared at that sequence.
       const blockB = { ...blockA, header: { ...blockA.header, proposer: key3 } }
       const digestB = await computeDigest(blockB)
-      const conflictingPrePrepare: PrePrepareMessage = {
-        type: 'pre-prepare', view: 1n, sequence: 1n, block: blockB, digest: digestB,
-      }
+      const conflictingPrePrepare: PrePrepareMessage =
+        await makePrePrepare(key2, 1n, 1n, blockB, digestB)
       network.createTransport(key2).send(key1, conflictingPrePrepare)
       await network.drainAll()
 
@@ -558,9 +579,8 @@ describe('PBFTConsensus', () => {
 
       // But re-proposing the SAME block (same digest) at the new view must
       // still be accepted — the guard only blocks conflicting proposals.
-      const samePrePrepare: PrePrepareMessage = {
-        type: 'pre-prepare', view: 1n, sequence: 1n, block: blockA, digest: digestA,
-      }
+      const samePrePrepare: PrePrepareMessage =
+        await makePrePrepare(key2, 1n, 1n, blockA, digestA)
       network.createTransport(key2).send(key1, samePrePrepare)
       await network.drainAll()
 
@@ -569,4 +589,118 @@ describe('PBFTConsensus', () => {
       p1.consensus.stop()
     })
   })
+  // A PREPARE is broadcast to every peer. If it signs the same bytes a COMMIT
+  // signs, then every peer holds a valid COMMIT from every prepared validator,
+  // and the commit phase proves nothing. See issue #17.
+  describe('vote signatures are bound to their phase, view and sequence', () => {
+    it('does not accept a PREPARE signature replayed as that validator COMMIT', async () => {
+      const p1 = createPeer(key1) // leader; quorum = 3 of 4
+      p1.consensus.start()
+
+      let finalized = 0
+      p1.consensus.onBlockFinalized(() => finalized++)
+
+      const block = makeBlock(1n, key1)
+      const digest = await computeDigest(block)
+      await p1.consensus.propose(block)
+
+      // Two honest PREPAREs — and nothing else from key2/key3.
+      const honestPrepares = []
+      for (const key of [key2, key3]) {
+        const msg = {
+          type: 'prepare' as const, view: 0n, sequence: 1n, digest, from: key,
+          signature: await signVote(key, 'prepare', 0n, 1n, digest),
+        }
+        honestPrepares.push(msg)
+        network.createTransport(key).send(key1, msg)
+      }
+      await network.drainAll()
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+
+      // Replay each PREPARE, byte for byte, as that validator's COMMIT.
+      for (const prepare of honestPrepares) {
+        network.createTransport(prepare.from).send(key1, {
+          type: 'commit', view: 0n, sequence: 1n, digest, from: prepare.from,
+          signature: prepare.signature,
+        })
+      }
+      await network.drainAll()
+
+      expect(finalized).toBe(0)
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+
+      p1.consensus.stop()
+    })
+
+    it('does not accept a PREPARE signature rewritten into another view or sequence', async () => {
+      const p1 = createPeer(key1)
+      p1.consensus.start()
+
+      const block = makeBlock(1n, key1)
+      const digest = await computeDigest(block)
+      await p1.consensus.propose(block)
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      // One honest PREPARE: 2 of the quorum of 3.
+      network.createTransport(key3).send(key1, {
+        type: 'prepare', view: 0n, sequence: 1n, digest, from: key3,
+        signature: await signVote(key3, 'prepare', 0n, 1n, digest),
+      })
+      await network.drainAll()
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      // key2's signature was made for (view 9, sequence 7) and is re-sent with
+      // the header fields rewritten to the round p1 is actually in. If the
+      // signed payload did not cover view and sequence this would be the third
+      // vote and would carry the round to Prepared.
+      network.createTransport(key2).send(key1, {
+        type: 'prepare', view: 0n, sequence: 1n, digest, from: key2,
+        signature: await signVote(key2, 'prepare', 9n, 7n, digest),
+      })
+      await network.drainAll()
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      // The same validator's correctly-scoped vote does reach quorum.
+      network.createTransport(key2).send(key1, {
+        type: 'prepare', view: 0n, sequence: 1n, digest, from: key2,
+        signature: await signVote(key2, 'prepare', 0n, 1n, digest),
+      })
+      await network.drainAll()
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+
+      p1.consensus.stop()
+    })
+
+    it('does not accept an unsigned or wrongly-signed PRE-PREPARE from the leader address', async () => {
+      const p2 = createPeer(key2) // key1 is leader for view 0
+      p2.consensus.start()
+
+      const block = makeBlock(1n, key1)
+      const digest = await computeDigest(block)
+
+      // Right sender, signature made by somebody else.
+      network.createTransport(key1).send(key2, {
+        type: 'pre-prepare', view: 0n, sequence: 1n, block, digest, from: key1,
+        signature: await signVote(key3, 'pre-prepare', 0n, 1n, digest),
+      })
+      await network.drainAll()
+      expect(p2.consensus.phase).toBe(PBFTPhase.Idle)
+
+      // Right sender, garbage signature.
+      network.createTransport(key1).send(key2, {
+        type: 'pre-prepare', view: 0n, sequence: 1n, block, digest, from: key1,
+        signature: new Uint8Array(32).fill(0xcd),
+      })
+      await network.drainAll()
+      expect(p2.consensus.phase).toBe(PBFTPhase.Idle)
+
+      // Properly signed by the leader — accepted.
+      network.createTransport(key1).send(key2, await makePrePrepare(key1, 0n, 1n, block, digest))
+      await network.drainAll()
+      expect(p2.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      p2.consensus.stop()
+    })
+  })
+
 })

--- a/packages/consensus/test/validator-set.test.ts
+++ b/packages/consensus/test/validator-set.test.ts
@@ -72,6 +72,37 @@ describe('ValidatorSet', () => {
       const keys = Array.from({ length: 7 }, (_, i) => makeTestKey(i + 1))
       expect(new ValidatorSet(keys).quorumSize()).toBe(5)
     })
+
+    const setOf = (n: number) =>
+      new ValidatorSet(Array.from({ length: n }, (_, i) => makeTestKey(i + 1)))
+
+    // The four sizes above are all n = 3f + 1, where the old `2f + 1` formula
+    // happened to be right. These are the sizes it was wrong for. See #19.
+    it('never lets a single node reach quorum in a multi-node set', () => {
+      for (let n = 2; n <= 24; n++) {
+        expect(setOf(n).quorumSize()).toBeGreaterThan(1)
+      }
+    })
+
+    it('guarantees any two quorums share at least one honest node, for every n', () => {
+      for (let n = 1; n <= 60; n++) {
+        const vs = setOf(n)
+        const q = vs.quorumSize()
+        const f = vs.maxFaults
+        // Two quorums overlap in at least 2q - n nodes; at most f of those can
+        // be Byzantine, so safety needs 2q - n >= f + 1.
+        expect(2 * q - n).toBeGreaterThanOrEqual(f + 1)
+        // And a quorum must be reachable when the tolerated faults are absent.
+        expect(q).toBeLessThanOrEqual(n - f)
+      }
+    })
+
+    it('still equals 2f + 1 at every canonical n = 3f + 1', () => {
+      for (let f = 0; f <= 12; f++) {
+        const n = 3 * f + 1
+        expect(setOf(n).quorumSize()).toBe(2 * f + 1)
+      }
+    })
   })
 
   it('maxFaults returns floor((n-1)/3)', () => {

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -16,34 +16,54 @@ export async function hashString(str: string): Promise<Uint8Array> {
   return hash(encoder.encode(str))
 }
 
-/** Compute a Merkle root from an array of leaf hashes. */
+/** Domain tag for a leaf position in the Merkle tree. */
+const MERKLE_LEAF = 0x00
+/** Domain tag for an internal node. */
+const MERKLE_NODE = 0x01
+
+/** `H(0x00 || leaf)` — a leaf hash can never be mistaken for a node hash. */
+async function merkleLeaf(leaf: Uint8Array): Promise<Uint8Array> {
+  const buf = new Uint8Array(1 + leaf.length)
+  buf[0] = MERKLE_LEAF
+  buf.set(leaf, 1)
+  return hash(buf)
+}
+
+/** `H(0x01 || left || right)`. */
+async function merkleNode(left: Uint8Array, right: Uint8Array): Promise<Uint8Array> {
+  const buf = new Uint8Array(1 + left.length + right.length)
+  buf[0] = MERKLE_NODE
+  buf.set(left, 1)
+  buf.set(right, 1 + left.length)
+  return hash(buf)
+}
+
+/**
+ * Compute a Merkle root from an array of leaf hashes.
+ *
+ * Leaves and internal nodes are domain-separated (`0x00` / `0x01`), and an odd
+ * level promotes its last node instead of duplicating it. Without both, the
+ * tree has the CVE-2012-2459 shape: `[A, B, C]` pads to `[A, B, C, C]` and the
+ * two lists produce an identical root, so a block's `txRoot` does not uniquely
+ * commit to its transaction list. A lone leaf was also returned unhashed, so
+ * "root" and "leaf" were the same value at n = 1.
+ */
 export async function merkleRoot(leaves: Uint8Array[]): Promise<Uint8Array> {
   if (leaves.length === 0) {
-    return hash(new Uint8Array(0))
-  }
-  if (leaves.length === 1) {
-    return leaves[0]
+    return hash(new Uint8Array([MERKLE_LEAF]))
   }
 
-  // Pad to even length by duplicating the last leaf
-  const padded = [...leaves]
-  if (padded.length % 2 !== 0) {
-    padded.push(padded[padded.length - 1])
-  }
+  let level: Uint8Array[] = await Promise.all(leaves.map(merkleLeaf))
 
-  // Build tree bottom-up
-  let level = padded
   while (level.length > 1) {
-    // Pad intermediate levels to even length too
-    if (level.length % 2 !== 0) {
-      level.push(level[level.length - 1])
-    }
     const next: Uint8Array[] = []
-    for (let i = 0; i < level.length; i += 2) {
-      const combined = new Uint8Array(level[i].length + level[i + 1].length)
-      combined.set(level[i], 0)
-      combined.set(level[i + 1], level[i].length)
-      next.push(await hash(combined))
+    for (let i = 0; i + 1 < level.length; i += 2) {
+      next.push(await merkleNode(level[i], level[i + 1]))
+    }
+    // Odd level: promote the last node unchanged rather than pairing it with
+    // itself, which is what makes a duplicated final leaf indistinguishable.
+    if (level.length % 2 !== 0) {
+      next.push(level[level.length - 1])
     }
     level = next
   }

--- a/packages/core/test/hash.test.ts
+++ b/packages/core/test/hash.test.ts
@@ -27,10 +27,13 @@ describe('merkleRoot', () => {
     expect(root.length).toBe(32)
   })
 
-  it('handles single leaf', async () => {
+  it('does not return a single leaf unhashed', async () => {
     const leaf = await hash(new Uint8Array([1]))
     const root = await merkleRoot([leaf])
-    expect(root).toEqual(leaf)
+    expect(root.length).toBe(32)
+    // A leaf and a root must not be the same value — otherwise a value an
+    // attacker supplies as a leaf is directly a root.
+    expect(root).not.toEqual(leaf)
   })
 
   it('handles two leaves', async () => {
@@ -59,6 +62,56 @@ describe('merkleRoot', () => {
     const r1 = await merkleRoot([a, b])
     const r2 = await merkleRoot([b, a])
     expect(r1).not.toEqual(r2)
+  })
+
+  // Duplicating the last leaf to pad an odd level made [A,B,C] and [A,B,C,C]
+  // hash to the same root, so a block's txRoot did not uniquely commit to its
+  // transaction list. See issue #21.
+  it('does not collide when the last leaf is duplicated', async () => {
+    const leaves = await Promise.all(
+      [1, 2, 3, 4, 5, 6, 7].map((n) => hash(new Uint8Array([n]))),
+    )
+    for (let n = 1; n <= leaves.length; n++) {
+      const list = leaves.slice(0, n)
+      const dup = [...list, list[list.length - 1]]
+      expect(await merkleRoot(list)).not.toEqual(await merkleRoot(dup))
+    }
+  })
+
+  it('gives every distinct leaf list a distinct root, up to 9 leaves', async () => {
+    const leaves = await Promise.all(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => hash(new Uint8Array([n]))),
+    )
+    const roots = new Set<string>()
+    // Every prefix, and every prefix with its last leaf repeated 1-3 times.
+    for (let n = 1; n <= leaves.length; n++) {
+      for (let extra = 0; extra <= 3; extra++) {
+        const list = leaves.slice(0, n)
+        for (let e = 0; e < extra; e++) list.push(list[n - 1])
+        roots.add(toHex(await merkleRoot(list)))
+      }
+    }
+    expect(roots.size).toBe(leaves.length * 4)
+  })
+
+  // Leaves and internal nodes must live in different domains. Without that,
+  // one fabricated leaf equal to the concatenation of two leaf hashes has the
+  // same root as the genuine two-leaf tree — a second preimage anyone can
+  // construct with two hash calls, using only the public API. See issue #21.
+  it('separates leaf hashes from internal-node hashes', async () => {
+    const a = new Uint8Array([1, 2, 3])
+    const b = new Uint8Array([4, 5, 6])
+
+    // A one-leaf root is that leaf's leaf-hash, so this reads the two leaf
+    // hashes back out of the implementation without assuming its encoding.
+    const leafA = await merkleRoot([a])
+    const leafB = await merkleRoot([b])
+
+    const forged = new Uint8Array(leafA.length + leafB.length)
+    forged.set(leafA, 0)
+    forged.set(leafB, leafA.length)
+
+    expect(await merkleRoot([forged])).not.toEqual(await merkleRoot([a, b]))
   })
 })
 

--- a/packages/da/src/celestia.ts
+++ b/packages/da/src/celestia.ts
@@ -11,13 +11,24 @@ import { hash, equal, toHex, fromHex } from '@johnhenry/raijin-core'
 import type { DALayer, DACommitment } from './types.js'
 
 export interface CelestiaDAOptions {
-  /** Base URL for the Celestia light node API. Default: http://localhost:26658 */
+  /** Base URL for the Celestia light node API. Default: http://localhost:26658
+   *  A cleartext `http:` endpoint is only accepted for loopback hosts when an
+   *  `authToken` is set -- see the constructor. */
   endpoint?: string
   /** Auth token for the node API (required by most Celestia nodes). */
   authToken?: string
   /** Namespace ID (8 bytes hex). Data is posted to this namespace. */
   namespace: string
+  /** Allow sending `authToken` to a non-loopback `http:` endpoint. Off by
+   *  default: the Celestia node auth token is a node credential, and on most
+   *  deployments it carries write access, so putting it in an `Authorization`
+   *  header over cleartext is never right by accident. Opt in only for a
+   *  network you control end to end. */
+  allowInsecureAuth?: boolean
 }
+
+/** Hosts for which cleartext `http:` is not a credential-disclosure risk. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1'])
 
 export class CelestiaDA implements DALayer {
   readonly name = 'celestia'
@@ -30,6 +41,17 @@ export class CelestiaDA implements DALayer {
     this.#endpoint = (options.endpoint ?? 'http://localhost:26658').replace(/\/$/, '')
     this.#authToken = options.authToken
     this.#namespace = options.namespace
+
+    if (this.#authToken && !options.allowInsecureAuth) {
+      const url = new URL(this.#endpoint)
+      if (url.protocol === 'http:' && !LOOPBACK_HOSTS.has(url.hostname)) {
+        throw new Error(
+          `CelestiaDA: refusing to send an auth token to ${url.origin} over cleartext http. ` +
+          'Use https, a loopback host, or pass allowInsecureAuth: true if the ' +
+          'network between this process and the node is genuinely trusted.',
+        )
+      }
+    }
   }
 
   async submit(data: Uint8Array): Promise<DACommitment> {
@@ -65,7 +87,10 @@ export class CelestiaDA implements DALayer {
   async retrieve(commitment: DACommitment): Promise<Uint8Array> {
     const height = commitment.height.toString()
     const res = await fetch(
-      `${this.#endpoint}/namespaced_data/${this.#namespace}/height/${height}`,
+      // Percent-encode: `namespace` is caller-supplied and would otherwise be
+      // able to rewrite the request path (`/`, `..`, `?`) and carry the auth
+      // token to a different node API route.
+      `${this.#endpoint}/namespaced_data/${encodeURIComponent(this.#namespace)}/height/${height}`,
       { headers: this.#headers() },
     )
 

--- a/packages/da/src/celestia.ts
+++ b/packages/da/src/celestia.ts
@@ -113,10 +113,21 @@ export class CelestiaDA implements DALayer {
 
 // ── Base64 helpers ─────────────────────────────────────────────────────
 
+/** Max bytes passed to `String.fromCharCode` per call. Spreading a whole blob
+ *  puts one argument on the stack per byte and throws RangeError somewhere
+ *  between 64 KiB and 128 KiB -- i.e. at the sizes a DA layer exists to
+ *  carry, and at a threshold that varies with engine and stack depth. */
+const BASE64_CHUNK = 0x8000
+
 function uint8ToBase64(data: Uint8Array): string {
-  // Works in both browser (btoa) and Node (Buffer)
+  // Works in both browser (btoa) and Node (Buffer). Node 18+ defines a global
+  // btoa, so the Buffer branch is a fallback for environments without either.
   if (typeof btoa === 'function') {
-    return btoa(String.fromCharCode(...data))
+    let binary = ''
+    for (let i = 0; i < data.length; i += BASE64_CHUNK) {
+      binary += String.fromCharCode(...data.subarray(i, i + BASE64_CHUNK))
+    }
+    return btoa(binary)
   }
   return Buffer.from(data).toString('base64')
 }

--- a/packages/da/test/celestia.test.ts
+++ b/packages/da/test/celestia.test.ts
@@ -118,4 +118,61 @@ describe('CelestiaDA', () => {
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
     expect(Buffer.from(body.data, 'base64').equals(Buffer.from(big))).toBe(true)
   })
+  // The auth token is a node credential; on most Celestia deployments it
+  // carries write access. Sending it over cleartext http to a remote host is
+  // never right by accident. See issue #24.
+  describe('auth token transport', () => {
+    it('refuses an auth token over cleartext http to a non-loopback host', () => {
+      expect(() => new CelestiaDA({
+        endpoint: 'http://celestia.internal:26658',
+        authToken: 'secret-node-token',
+        namespace: 'ns1',
+      })).toThrow(/cleartext http/)
+    })
+
+    it('allows an auth token over loopback http', () => {
+      expect(() => new CelestiaDA({
+        endpoint: 'http://127.0.0.1:26658',
+        authToken: 'secret-node-token',
+        namespace: 'ns1',
+      })).not.toThrow()
+    })
+
+    it('allows an auth token over https', () => {
+      expect(() => new CelestiaDA({
+        endpoint: 'https://celestia.internal:26658',
+        authToken: 'secret-node-token',
+        namespace: 'ns1',
+      })).not.toThrow()
+    })
+
+    it('allows an explicit opt-in for a trusted plaintext network', () => {
+      expect(() => new CelestiaDA({
+        endpoint: 'http://celestia.internal:26658',
+        authToken: 'secret-node-token',
+        namespace: 'ns1',
+        allowInsecureAuth: true,
+      })).not.toThrow()
+    })
+
+    it('does not object to cleartext http when no auth token is set', () => {
+      expect(() => new CelestiaDA({
+        endpoint: 'http://celestia.internal:26658',
+        namespace: 'ns1',
+      })).not.toThrow()
+    })
+  })
+
+  // `namespace` is caller-supplied and was interpolated into the URL path raw,
+  // so it could rewrite the request route and carry the auth token elsewhere.
+  it('percent-encodes the namespace in the retrieve URL', async () => {
+    const da = new CelestiaDA({ endpoint: 'http://localhost:26658', namespace: '../../evil?x=' })
+    fetchMock.mockResolvedValue(jsonResponse({ data: [] }))
+
+    await expect(da.retrieve({ layer: 'celestia', height: 1n, index: 0, hash: new Uint8Array(32) }))
+      .rejects.toThrow()
+
+    const url = fetchMock.mock.calls[0][0] as string
+    expect(url).toBe('http://localhost:26658/namespaced_data/..%2F..%2Fevil%3Fx%3D/height/1')
+  })
 })

--- a/packages/da/test/celestia.test.ts
+++ b/packages/da/test/celestia.test.ts
@@ -100,4 +100,22 @@ describe('CelestiaDA', () => {
     const commitment = { layer: 'celestia', height: 3n, index: 0, hash: new Uint8Array(32) }
     expect(await da.verify(commitment)).toBe(false)
   })
+  // Regression: uint8ToBase64 spread the whole blob into String.fromCharCode,
+  // one argument per byte, and threw RangeError between 64 KiB and 128 KiB --
+  // exactly the sizes a DA layer carries. See issue #22.
+  it('submit encodes a 1 MiB blob without overflowing the stack', async () => {
+    const da = new CelestiaDA({ endpoint: 'http://localhost:26658', namespace: 'ns1' })
+    fetchMock.mockResolvedValue(jsonResponse({ height: 7, txhash: 'abc' }))
+
+    const big = new Uint8Array(1024 * 1024)
+    for (let i = 0; i < big.length; i++) big[i] = i & 0xff
+
+    const commitment = await da.submit(big)
+    expect(commitment.height).toBe(7n)
+    expect(equal(commitment.hash, await hash(big))).toBe(true)
+
+    // The blob round-trips through base64 byte-for-byte.
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(Buffer.from(body.data, 'base64').equals(Buffer.from(big))).toBe(true)
+  })
 })

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -31,6 +31,7 @@ const tx = await wallet.buildTx({
   to: recipientPublicKey,     // Uint8Array(32), or null for system ops
   value: 250n,
   nonce: account.nonce,
+  chainId: 1n,                // required — see below
 })
 
 const receipt = await client.submitTransaction(tx)  // { txHash, status, revertReason?, index }
@@ -45,14 +46,17 @@ A complete end-to-end run — real Ed25519 verification against an in-process `V
 
 | Member | Purpose |
 | --- | --- |
-| `static generate(): Promise<Wallet>` | New Ed25519 keypair via `crypto.subtle.generateKey`. |
+| `static generate(opts?): Promise<Wallet>` | New Ed25519 keypair via `crypto.subtle.generateKey`. **Non-extractable by default** — pass `{ extractable: true }` only if the key has to be exported. |
 | `static fromKey(pkcs8: Uint8Array): Promise<Wallet>` | Import a private key (PKCS8); the public key is derived from it. |
 | `publicKey: Uint8Array` | 32-byte raw public key — this is your address. |
 | `sign(message): Promise<Uint8Array>` | Raw Ed25519 signature (64 bytes, deterministic). |
-| `buildTx(opts: BuildTxOptions): Promise<Transaction>` | Assembles `{ from: publicKey, to, value, nonce, data?, chainId? }` and signs it. |
-| `exportPrivateKey(): Promise<Uint8Array>` | PKCS8 bytes for storage; round-trips through `fromKey()`. |
+| `buildTx(opts: BuildTxOptions): Promise<Transaction>` | Assembles `{ from: publicKey, to, value, nonce, data?, chainId }` and signs it. |
+| `exportPrivateKey(): Promise<Uint8Array>` | PKCS8 bytes for storage; round-trips through `fromKey()`. Throws unless the wallet was generated with `{ extractable: true }`. |
 
-`BuildTxOptions`: `{ to, value, nonce, data?, chainId? }` — `data` defaults to empty (which the state machine treats as a `Transfer`; set `data[0]` to a `TransactionType` byte for anything else).
+`BuildTxOptions`: `{ to, value, nonce, data?, chainId }` — `data` defaults to empty (which the state machine treats as a `Transfer`; set `data[0]` to a `TransactionType` byte for anything else).
+
+- **`chainId` is required.** It is the only field separating one deployment from another, so a default would give every chain that never chose one the same id, and a signed transfer on either would be a valid signed transfer on the other for any account whose key is shared between them.
+- **Private keys are non-extractable unless you ask.** In a browser that is the strongest guarantee WebCrypto offers: the key cannot leave the browser, whatever script asks for it. `exportPrivateKey()` needs `Wallet.generate({ extractable: true })`.
 
 ### `RaijinClient`
 

--- a/packages/sdk/src/wallet.ts
+++ b/packages/sdk/src/wallet.ts
@@ -15,7 +15,28 @@ export interface BuildTxOptions {
   value: bigint
   nonce: bigint
   data?: Uint8Array
-  chainId?: bigint
+  /**
+   * Chain identifier. Required — it is the only thing in the transaction
+   * format that separates one deployment from another, so a default would
+   * make every chain that never chose one share an id, and a signed transfer
+   * on either would be a valid signed transfer on the other for any account
+   * whose key is shared between them.
+   */
+  chainId: bigint
+}
+
+export interface GenerateOptions {
+  /**
+   * Whether the private key can be exported with `exportPrivateKey()`.
+   * Default: `false`.
+   *
+   * Raijin's stated environment is the browser, where a non-extractable
+   * `CryptoKey` is the strongest guarantee WebCrypto offers: the key cannot
+   * leave the browser, whatever script asks. An extractable key is one
+   * `crypto.subtle.exportKey` call away from any code running in the origin.
+   * Turn this on only when the key genuinely has to be persisted or moved.
+   */
+  extractable?: boolean
 }
 
 export class Wallet implements TransactionSigner {
@@ -27,11 +48,15 @@ export class Wallet implements TransactionSigner {
     this.#publicKeyBytes = publicKeyBytes
   }
 
-  /** Generate a new Ed25519 keypair. */
-  static async generate(): Promise<Wallet> {
+  /**
+   * Generate a new Ed25519 keypair. The private key is **non-extractable**
+   * unless `{ extractable: true }` is passed — see `GenerateOptions`.
+   */
+  static async generate(opts: GenerateOptions = {}): Promise<Wallet> {
+    const extractable = opts.extractable ?? false
     const keyPair = await globalThis.crypto.subtle.generateKey(
       'Ed25519',
-      true, // extractable
+      extractable,
       ['sign', 'verify'],
     ) as CryptoKeyPair
 
@@ -84,13 +109,19 @@ export class Wallet implements TransactionSigner {
 
   /** Build and sign a transaction. */
   async buildTx(opts: BuildTxOptions): Promise<Transaction> {
+    // Guard the JS callers the type system does not reach: an undefined
+    // chainId would otherwise be encoded as a chain id of its own.
+    if (typeof opts.chainId !== 'bigint') {
+      throw new TypeError('Wallet.buildTx: chainId is required and must be a bigint')
+    }
+
     const tx: Transaction = {
       from: this.#publicKeyBytes,
       to: opts.to,
       value: opts.value,
       nonce: opts.nonce,
       data: opts.data ?? new Uint8Array(0),
-      chainId: opts.chainId ?? 1n,
+      chainId: opts.chainId,
       signature: new Uint8Array(0), // placeholder
     }
 
@@ -101,8 +132,17 @@ export class Wallet implements TransactionSigner {
     return tx
   }
 
-  /** Export the private key as PKCS8 bytes. */
+  /**
+   * Export the private key as PKCS8 bytes.
+   * Throws unless the wallet was created with `{ extractable: true }`.
+   */
   async exportPrivateKey(): Promise<Uint8Array> {
+    if (!this.#privateKey.extractable) {
+      throw new Error(
+        'Wallet.exportPrivateKey: this key is non-extractable. ' +
+        'Pass Wallet.generate({ extractable: true }) if the key has to leave the process.',
+      )
+    }
     const pkcs8 = await globalThis.crypto.subtle.exportKey('pkcs8', this.#privateKey)
     return new Uint8Array(pkcs8)
   }

--- a/packages/sdk/src/wallet.ts
+++ b/packages/sdk/src/wallet.ts
@@ -46,7 +46,9 @@ export class Wallet implements TransactionSigner {
   static async fromKey(pkcs8: Uint8Array): Promise<Wallet> {
     const privateKey = await globalThis.crypto.subtle.importKey(
       'pkcs8',
-      pkcs8.buffer as ArrayBuffer,
+      // Pass the view, not `.buffer` — a Uint8Array that is a window into a
+      // larger ArrayBuffer would otherwise import the whole buffer.
+      pkcs8 as BufferSource,
       'Ed25519',
       true,
       ['sign'],
@@ -71,7 +73,11 @@ export class Wallet implements TransactionSigner {
     const signature = await globalThis.crypto.subtle.sign(
       'Ed25519',
       this.#privateKey,
-      message.buffer as ArrayBuffer,
+      // Pass the view itself. `message.buffer` ignores byteOffset/byteLength,
+      // so any Uint8Array produced by `subarray()` or backed by a pooled
+      // buffer would be signed in full — bytes the caller never saw, and
+      // bytes `verifyEd25519` (which passes the view) would not verify.
+      message as BufferSource,
     )
     return new Uint8Array(signature)
   }

--- a/packages/sdk/test/wallet.test.ts
+++ b/packages/sdk/test/wallet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { encodeTx } from '@johnhenry/raijin-core'
+import { encodeTx, verifyEd25519 } from '@johnhenry/raijin-core'
 import { Wallet } from '../src/wallet.js'
 
 // ── Tests ──
@@ -87,5 +87,40 @@ describe('Wallet', () => {
     const sig1 = await wallet.sign(msg)
     const sig2 = await restored.sign(msg)
     expect(sig1).toEqual(sig2)
+  })
+  // Regression: sign() used to pass `message.buffer`, which ignores
+  // byteOffset/byteLength — so any Uint8Array that is a window into a larger
+  // buffer was signed in full. verifyEd25519() passes the view, so the library
+  // rejected its own signatures. See issue #20.
+  it('signs the view, not the whole backing ArrayBuffer', async () => {
+    const wallet = await Wallet.generate()
+
+    const backing = new Uint8Array(64).fill(7)
+    const view = backing.subarray(0, 32)
+    const standalone = new Uint8Array(32).fill(7)
+
+    const sigView = await wallet.sign(view)
+    const sigStandalone = await wallet.sign(standalone)
+
+    // Same 32 bytes, same signature — regardless of what surrounds them.
+    expect(sigView).toEqual(sigStandalone)
+
+    // The library verifies its own signature over the view...
+    expect(await verifyEd25519(view, sigView, wallet.publicKey)).toBe(true)
+    // ...and does NOT accept it over the 64-byte buffer it sits inside.
+    expect(await verifyEd25519(backing, sigView, wallet.publicKey)).toBe(false)
+  })
+
+  it('reimports a PKCS8 key held in a larger buffer', async () => {
+    const wallet = await Wallet.generate()
+    const pkcs8 = await wallet.exportPrivateKey()
+
+    // Same bytes, but as a view with a non-zero byteOffset.
+    const padded = new Uint8Array(pkcs8.length + 16)
+    padded.set(pkcs8, 8)
+    const view = padded.subarray(8, 8 + pkcs8.length)
+
+    const restored = await Wallet.fromKey(view)
+    expect(restored.publicKey).toEqual(wallet.publicKey)
   })
 })

--- a/packages/sdk/test/wallet.test.ts
+++ b/packages/sdk/test/wallet.test.ts
@@ -43,13 +43,14 @@ describe('Wallet', () => {
       to: recipient,
       value: 100n,
       nonce: 0n,
+      chainId: 1n,
     })
 
     expect(tx.from).toEqual(wallet.publicKey)
     expect(tx.to).toEqual(recipient)
     expect(tx.value).toBe(100n)
     expect(tx.nonce).toBe(0n)
-    expect(tx.chainId).toBe(1n) // default
+    expect(tx.chainId).toBe(1n)
     expect(tx.signature.length).toBe(64)
   })
 
@@ -69,7 +70,7 @@ describe('Wallet', () => {
   })
 
   it('exports and reimports a private key', async () => {
-    const wallet = await Wallet.generate()
+    const wallet = await Wallet.generate({ extractable: true })
     const pkcs8 = await wallet.exportPrivateKey()
     expect(pkcs8).toBeInstanceOf(Uint8Array)
     expect(pkcs8.length).toBeGreaterThan(0)
@@ -79,7 +80,7 @@ describe('Wallet', () => {
   })
 
   it('reimported wallet produces same signatures', async () => {
-    const wallet = await Wallet.generate()
+    const wallet = await Wallet.generate({ extractable: true })
     const pkcs8 = await wallet.exportPrivateKey()
     const restored = await Wallet.fromKey(pkcs8)
 
@@ -112,7 +113,7 @@ describe('Wallet', () => {
   })
 
   it('reimports a PKCS8 key held in a larger buffer', async () => {
-    const wallet = await Wallet.generate()
+    const wallet = await Wallet.generate({ extractable: true })
     const pkcs8 = await wallet.exportPrivateKey()
 
     // Same bytes, but as a view with a non-zero byteOffset.
@@ -122,5 +123,32 @@ describe('Wallet', () => {
 
     const restored = await Wallet.fromKey(view)
     expect(restored.publicKey).toEqual(wallet.publicKey)
+  })
+  // Convenient-but-unsafe defaults. See issue #23.
+  describe('secure defaults', () => {
+    it('generates a non-extractable private key by default', async () => {
+      const wallet = await Wallet.generate()
+      await expect(wallet.exportPrivateKey()).rejects.toThrow(/non-extractable/)
+    })
+
+    it('exports only when extractability was asked for', async () => {
+      const wallet = await Wallet.generate({ extractable: true })
+      const pkcs8 = await wallet.exportPrivateKey()
+      expect(pkcs8.length).toBeGreaterThan(0)
+    })
+
+    it('a non-extractable wallet still signs', async () => {
+      const wallet = await Wallet.generate()
+      const sig = await wallet.sign(new Uint8Array([1, 2, 3]))
+      expect(sig.length).toBe(64)
+    })
+
+    it('refuses to build a transaction with no chainId', async () => {
+      const wallet = await Wallet.generate()
+      await expect(
+        // chainId is required at the type level; this is the JS caller.
+        (wallet.buildTx as (o: unknown) => Promise<unknown>)({ to: null, value: 0n, nonce: 0n }),
+      ).rejects.toThrow(/chainId is required/)
+    })
   })
 })


### PR DESCRIPTION
Nine changes across consensus, DA, core hashing and the SDK. Several are safety-relevant and
would be exploitable in a byzantine setting, which is the setting this library exists for.

## Consensus

**Vote signatures were not bound to their phase, view or sequence.** A signature captured in
one phase verified in another, so a prepare vote could be replayed as a commit vote. Each
signature now covers the phase, view and sequence it was cast in.

**The quorum was not safe at every validator count.** Using the wrong threshold means two
conflicting quorums can both form. Now `n - f`, which holds at every count rather than only
the convenient ones.

**A view could move backwards**, which lets a stale message drag the node back into a view it
had already left.

## Data availability

**`CelestiaDA` leaked its auth token over cleartext HTTP**, and again via the namespace. A
credential that reaches the wire in plaintext is compromised regardless of what the rest of
the protocol does.

**Its base64 encoder broke on blobs above 64 KiB** — the encoder was called in a way that
exceeds the argument limit, so large blobs failed. Now chunked.

## Core

**`merkleRoot` did not produce a unique root per leaf list.** Different leaf lists could
produce the same root, which defeats the point of a merkle root: an inclusion proof is only
meaningful if the root commits to exactly one list.

## SDK

**The signer signed the `ArrayBuffer` backing a `Uint8Array` view rather than the view
itself.** When the view is a subarray, those are different bytes — so the signature covers
data the caller never intended to sign, and verification of the intended bytes fails.

**Keys are now non-extractable by default**, and `chainId` must be given explicitly rather
than defaulting, so a signature cannot be replayed onto a chain the caller did not name.

## One pre-existing failure, not introduced here

`packages/validator/test/block-producer.test.ts` — "chains parentHash to the previous block
real (non-zero) stateRoot" — fails on this branch **and on `main`**. I isolated it: reverting
only the `merkleRoot` change leaves it failing, so it is not caused by this work. Filed
separately. Everything else is green: sdk 21, core 39, da 30, consensus 39, validator 15 of 16.
