### PR TITLE
The Byzantine harness, the last ambiguous encoding, and the 0.0.1 release metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,18 @@ jobs:
         run: npm run typecheck
 
       - name: Publish packages
-        run: npm publish --workspaces --access public
+        # Dependency order, not alphabetical. `npm publish --workspaces`
+        # iterates alphabetically -- consensus before core -- and every
+        # dependent now requires `@johnhenry/raijin-core@^0.0.1`, which does
+        # not exist on the registry until core itself is published. Publishing
+        # out of order fails the dependent, or worse, resolves an older core.
+        # `raijin-test-harness` is private and npm skips it on its own.
+        run: |
+          npm publish -w @johnhenry/raijin-core      --access public
+          npm publish -w @johnhenry/raijin-consensus --access public
+          npm publish -w @johnhenry/raijin-mempool   --access public
+          npm publish -w @johnhenry/raijin-da        --access public
+          npm publish -w @johnhenry/raijin-sdk       --access public
+          npm publish -w @johnhenry/raijin-validator --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ account and receipt encodings, and the state root. A node running these
 changes cannot talk to one that isn't — different digests, different
 signatures, different roots.
 
+Vote payloads changed twice: first to cover the phase, view and sequence, and
+then again to cover the **chain id** and a **validator-set epoch**, so that a
+vote cannot be replayed onto a different deployment or counted across a
+membership change. `voteDigest()` now takes a single object, and `chainId` is
+required — with no default — on `PBFTConfig` and `ValidatorNodeConfig`.
+
+Two more unsafe defaults closed alongside them: `Wallet.fromKey()` imports
+non-extractable keys unless the call site asks otherwise (it previously
+hardcoded extractable, on the path persisted keys come back through), and
+`@johnhenry/raijin-da`'s `decode()` caps decompressed output at 16 MiB
+instead of running an unbounded `inflateSync` over untrusted DA bytes.
+
 **See [`MIGRATION.md`](./MIGRATION.md)** for the format-by-format inventory
 and the upgrade checklist. The short version: upgrade every node at once,
 from a fresh genesis, and discard persisted state (account records written by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased — hashed formats change before 0.0.1 (2026-09-04)
+
+The security fixes on this branch changed every format Raijin hashes or
+signs: vote payloads, Merkle roots, the block header, the transaction,
+account and receipt encodings, and the state root. A node running these
+changes cannot talk to one that isn't — different digests, different
+signatures, different roots.
+
+**See [`MIGRATION.md`](./MIGRATION.md)** for the format-by-format inventory
+and the upgrade checklist. The short version: upgrade every node at once,
+from a fresh genesis, and discard persisted state (account records written by
+an earlier build no longer decode).
+
 ## Unreleased — documentation overhaul + runnable examples (2026-08-25)
 
 Documentation only, plus example scripts and a CI smoke step — no library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,182 @@
 # Changelog
 
-## Unreleased — hashed formats change before 0.0.1 (2026-09-04)
+## 0.0.1 — the first release that is safe to run (2026-09-04)
 
-The security fixes on this branch changed every format Raijin hashes or
-signs: vote payloads, Merkle roots, the block header, the transaction,
-account and receipt encodings, and the state root. A node running these
-changes cannot talk to one that isn't — different digests, different
-signatures, different roots.
+All six published packages, together. **Upgrade from `0.0.0`.**
+
+`0.0.0` and every unscoped release before it (`raijin-core@0.0.1`,
+`raijin-consensus@0.0.3` and siblings) shipped a consensus engine that
+collected vote signatures without ever verifying one, finalized on a quorum
+that degenerates to a single node at two or three validators, and derived its
+block hashes, Merkle roots and state roots from encodings that two different
+structures could share. Those are not hardening opportunities; they are the
+properties the library exists to provide, and they were absent. This release
+supplies them. It is the first version of Raijin anyone should install.
+
+### Can I keep my data? No.
+
+This is a hard break, from a fresh genesis. Every format Raijin hashes or
+signs changed: vote payloads, Merkle roots, the block header, the state key,
+the transaction, account, receipt and state-entry encodings, and the state
+root. Account records written by an earlier build are stored under keys an
+upgraded node does not look up, and would be rejected by `decodeAccount` if it
+found them. There is no state-format converter. Discard persisted state and
+re-seed genesis balances.
+
+### Can my nodes talk to nodes on 0.0.0? No.
+
+There is no compatibility mode and no negotiation. A 0.0.1 node and a 0.0.0
+node compute different block digests (so PRE-PREPARE is rejected as a digest
+mismatch), different vote payloads (so every signature verification fails),
+and different state roots (so even agreement on a block would leave them on
+divergent chains). Stop every node and upgrade them together — a partial
+upgrade is worse than a stopped network, because each half considers the
+other's blocks invalid. Clients that sign transactions must be upgraded too.
+
+[`MIGRATION.md`](./MIGRATION.md) has the format-by-format inventory, the API
+breaks, and the operator checklist.
+
+### Security fixes
+
+**Consensus.**
+
+- **Vote signatures are verified.** PRE-PREPARE, PREPARE, COMMIT and
+  VIEW-CHANGE are checked against the claimed sender before they count toward
+  anything. Previously they were collected and never verified, so any peer
+  that could reach the message handler could forge votes on behalf of any
+  validator. `PBFTConfig.verify` is now a required field; there is no
+  unverified mode.
+- **Each signature is bound to exactly one use.** A vote is signed over
+  `voteDigest({ phase, chainId, epoch, view, sequence, digest })`. Signing the
+  bare digest meant a PREPARE — broadcast to every peer — *was* a valid COMMIT
+  from the same validator, so the commit phase proved nothing; and a signature
+  not covering view/sequence could be lifted into a later round unchanged.
+  `chainId` stops one deployment's votes being counted by another. `epoch`, a
+  digest of the exact validator set and order, stops a removed validator's
+  still-valid signatures counting toward the quorum of the set that removed
+  them.
+- **The quorum is `n - f`, not `2f + 1`.** `2f + 1` is only safe at
+  `n = 3f + 1`; at `n = 2` or `n = 3` it degenerates to `q = 1`, letting one
+  node reach its own PREPARE and COMMIT quorum and finalize blocks alone.
+  `n - f` satisfies the overlap condition `2q - n >= f + 1` at every validator
+  count.
+- **Views only move forward.** A VIEW-CHANGE signature covers nothing
+  time-bound, so a recorded quorum stays valid forever; replaying one used to
+  rewind the view and clear every in-flight round, indefinitely, with no keys
+  required. VIEW-CHANGE messages are also deduplicated by sender, and NEW-VIEW
+  is honoured only when backed by a real quorum of validly-signed,
+  distinct-sender VIEW-CHANGEs.
+
+**Encoding — swept as a class, not case by case.** Two rules now hold
+everywhere: every variable-length field carries its length, and every distinct
+structure carries a domain tag.
+
+- Domain tags `0x01`–`0x07` across `encodeTx`, `encodeTxSigned`,
+  `encodeAccount`, `encodeReceipt`, `encodeBlockHeader`, `encodeStateEntry`
+  and state keys. `decodeAccount` rejects anything not tagged as an account
+  rather than misreading it.
+- `merkleRoot` commits uniquely to its leaf list: `0x00`/`0x01` leaf and node
+  tags, and an odd level promotes its last node instead of duplicating it.
+  Without both, `[A, B, C]` and `[A, B, C, C]` produce the same root
+  (CVE-2012-2459), so a block's `txRoot` did not uniquely commit to its
+  transactions. A lone leaf was also returned unhashed, making "root" and
+  "leaf" the same value at n = 1.
+- `InMemoryStateStore.root()` is a Merkle tree over domain-tagged, fully
+  length-prefixed entries, ordered by key bytes. It was `H(key₀ ‖ value₀ ‖ …)`
+  with no prefixes and `localeCompare` ordering — so a store holding key
+  `0xab` with value `"cd"` and one holding key `0xabcd` with an empty value
+  produced the same root, and two runtimes could order identical state
+  differently.
+- State keys are `0x07 ‖ len(ns) ‖ ns ‖ len(id) ‖ id`. The bare
+  `namespace ‖ id` concatenation they replace was unambiguous only by
+  coincidence — the shipped namespaces happen to be prefix-free and every id
+  happens to be 32 bytes, and nothing enforced either. Use the new
+  `accountKey`/`stateKey` exports rather than building keys by hand.
+- `u64()` throws on out-of-range input instead of silently truncating to the
+  high 8 bytes, which let two different block numbers encode identically.
+- `parentHash` is the parent's canonical block hash,
+  `blockHash(parent) = H(encodeBlockHeader(parent.header))`, exported. It was
+  the parent's *state root*, which commits to the resulting account state and
+  nothing else — not the transactions, proposer, timestamp or roots — so any
+  two blocks leaving the same post-state were indistinguishable as parents,
+  and an empty block's child pointed at a hash equal to the block's own.
+- Block `stateRoot` and `receiptRoot` are computed after execution instead of
+  being left as zero-filled placeholders forever.
+
+**Data availability.**
+
+- `CelestiaDA` no longer sends its auth token over cleartext `http:` to a
+  non-loopback host (the token is a node credential and usually carries write
+  access); opt back in with `allowInsecureAuth`. The caller-supplied namespace
+  is percent-encoded so it cannot rewrite the request path and carry the token
+  to a different route.
+- Its base64 encoder is chunked, so blobs above 64 KiB survive instead of
+  overflowing the call stack.
+- `decode()` caps decompressed output at 16 MiB. DA bytes are untrusted by
+  definition and DEFLATE reaches roughly 1000:1, so a few kilobytes could ask
+  for gigabytes. The compressed frame now declares its decompressed length,
+  which is checked *before* inflating and then used as a hard bound on the
+  inflater. Rejections are `DADecodeError` / `DASizeLimitError` rather than
+  whatever the compression library threw.
+
+**SDK.**
+
+- `Wallet` signs the `Uint8Array` view rather than its backing `ArrayBuffer` —
+  a view into a larger buffer previously signed the whole buffer.
+- Keys are non-extractable by default on `fromKey()` as well as `generate()`.
+  `fromKey` is the persistence path, where a stored key comes back, so
+  importing extractable by default quietly undid the `generate()` default for
+  exactly the keys that live longest.
+- `chainId` is required when building a transaction, with no default.
+
+**Validator.**
+
+- `ValidatorNode` runs the real fee-ordered, signature-verifying mempool from
+  `@johnhenry/raijin-mempool` instead of an unvalidated FIFO queue.
+  `submitTransaction()` now rejects a bad signature or a duplicate
+  sender+nonce outright rather than accepting it and reverting it a block
+  later. `@johnhenry/raijin-validator` re-exports that class; its own is gone.
+- The canonical transaction id is the signed encoding everywhere — receipt
+  `txHash`, `txRoot` leaves, mempool keys.
+
+### Tests
+
+251 → 254 across the seven workspace packages, 229 of them in the six
+published ones. The new coverage is adversarial rather than incidental: a
+Byzantine harness with an equivocating proposer and a vote replayed across
+phases, both proven non-vacuous by injection — restoring the `2f + 1` quorum
+produces a real fork, with two distinct blocks finalized across honest
+replicas, and unbinding a vote's phase lets a block finalize on a manufactured
+commit quorum.
+
+### Documentation
+
+Every README claim was re-checked against the code, and the ones this work
+falsified were corrected rather than deleted — including
+`packages/consensus/README.md`'s "the signatures carried on COMMIT messages
+are collected, not verified; authentication is your transport's job," which
+had become false in the most dangerous direction: it told a reader not to rely
+on a guarantee the code now makes. Its replacement states what the engine
+authenticates and what the transport still owes (delivery, Sybil resistance,
+the membership list, and the correctness of the injected verifier). The
+quorum tables, the `2f + 1` arithmetic, the `parentHash` semantics, the
+`chainId` default, the receipt-`txHash` encoding and the two-`Mempool` story
+were all stale in the same way and are now accurate.
+
+### Housekeeping
+
+- All six published packages `0.0.0` → `0.0.1`, with every internal dependency
+  range moved `^0.0.0` → `^0.0.1` in the same change. `0.0.1` does not satisfy
+  `^0.0.0`, and all six are already published at `0.0.0`, so a version-only
+  bump would have installed the old, vulnerable core alongside the new
+  packages. `raijin-test-harness` is `private: true` and stays at `0.1.0`.
+
+### Development log — the encoding pass (2026-09-04)
+
+Every format Raijin hashes or signs changed: vote payloads, Merkle roots, the
+block header, state keys, the transaction, account, receipt and state-entry
+encodings, and the state root. A node running these changes cannot talk to one
+that isn't — different digests, different signatures, different roots.
 
 Vote payloads changed twice: first to cover the phase, view and sequence, and
 then again to cover the **chain id** and a **validator-set epoch**, so that a
@@ -25,10 +195,16 @@ and the upgrade checklist. The short version: upgrade every node at once,
 from a fresh genesis, and discard persisted state (account records written by
 an earlier build no longer decode).
 
-## Unreleased — documentation overhaul + runnable examples (2026-08-25)
+### Development log — documentation overhaul + runnable examples (2026-08-25)
 
 Documentation only, plus example scripts and a CI smoke step — no library
 source changes.
+
+> Several "sharp edges" this pass documented were *fixed* later in the same
+> release and no longer describe 0.0.1: the quorum below four validators, the
+> two `Mempool` classes, and the zeroed roots in produced headers. The
+> READMEs were re-checked claim by claim before release; see "Documentation"
+> above.
 
 - **All six per-package READMEs rewritten** from provenance-only stubs into
   real API documentation: full export surface with signatures, quick starts,
@@ -51,7 +227,7 @@ source changes.
 - **CI**: `.github/workflows/ci.yml` gains an "Examples smoke test" step
   running `npm run examples` after build/test/typecheck.
 
-## Unreleased — npm workspaces + Turborepo (2026-08-25)
+### Development log — npm workspaces + Turborepo (2026-08-25)
 
 Converts the monorepo's package manager from pnpm to plain `npm` workspaces,
 standardizing on the same tooling as the rest of the `@johnhenry` family

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,7 +29,8 @@ differ regardless.
 
 | Format | Before | After | Consequence |
 | --- | --- | --- | --- |
-| PBFT vote signatures (`voteDigest`) | signature over the bare block digest | `H(phase tag ‖ 0x00 ‖ chainId ‖ epoch ‖ view ‖ sequence ‖ digest)`, tags bumped `v1` → `v2`, integers LEB128, `epoch`/`digest` length-prefixed | every PREPARE/COMMIT/VIEW-CHANGE/PRE-PREPARE signature changes; old signatures verify nowhere. A vote is now scoped to one chain and one validator set as well as one phase and round |
+| PBFT vote signatures (`voteDigest`) | signature over the bare block digest | `H(phase tag ‖ 0x00 ‖ chainId ‖ epoch ‖ view ‖ sequence ‖ digest)`, tags bumped `v1` → `v2`, integers LEB128, `epoch`/`digest` length-prefixed | every PREPARE/COMMIT/VIEW-CHANGE signature changes and old signatures verify nowhere. PRE-PREPARE is a separate case — it carried no signature at all before, see the row below. A vote is now scoped to one chain and one validator set as well as one phase and round |
+| PRE-PREPARE message shape (`PrePrepareMessage`) | `{ type, view, sequence, block, digest }` — **no `from`, no `signature`** | the same plus required `from` and `signature`, signed over `voteDigest({ phase: 'pre-prepare', … })` | a proposal from an older node has no signature field and is rejected; a proposal from a newer node carries two fields an older node ignores, so it accepts an unauthenticated proposal. **If your transport serialises these structs by hand, it must carry the two new fields** — a JSON transport that silently drops them produces a chain that never finalises and reports no error |
 | DA compressed frame (`@johnhenry/raijin-da` `encode`/`decode`) | `"RJC" ‖ deflate(data)` | `"RJC" ‖ LEB128(decompressed length) ‖ deflate(data)` | a compressed blob written by an earlier build has no length header and is rejected; `decode()` refuses anything over `maxDecompressedSize` (16 MiB by default) |
 | `merkleRoot` | plain pairwise hashing, last leaf duplicated on odd levels, single leaf returned unhashed | `0x00` leaf / `0x01` node domain tags, odd level promotes, empty list is `H(0x00)` | every `txRoot` and `receiptRoot` changes |
 | Block header encoding (`encodeBlockHeader`, new export) | ad-hoc concatenation inside PBFT | domain tag `0x05`, length-prefixed roots and proposer, range-checked `u64` fields | the consensus digest changes; the header layout now has exactly one definition, shared by PBFT and `blockHash` |
@@ -87,8 +88,10 @@ differ regardless.
 These landed before the encoding work and are also new to anyone on 0.0.0.
 
 - **`PBFTConfig.verify` is required** — a `SignatureVerifier` used to check
-  every PRE-PREPARE, PREPARE, COMMIT and VIEW-CHANGE. There was previously no
-  such field, because votes were never verified. `ValidatorNode` supplies it
+  every PREPARE, COMMIT and VIEW-CHANGE. There was previously no such field,
+  because votes were never verified. (PRE-PREPARE could not be checked by that
+  earlier pass: the message carried no signature to check until 0.0.1 added
+  one — see the format table above.) `ValidatorNode` supplies it
   from `identity.verify`, which means that one verifier now authenticates
   consensus votes as well as transactions: a stub that returns `true`
   unconditionally is no longer merely permissive about transactions, it

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,54 @@
+# Migration notes
+
+## Unreleased → 0.0.1 — every hashed and signed format changed
+
+The security work leading to 0.0.1 fixed a family of encoding bugs in which
+two different structures could produce the same bytes, and therefore the same
+hash, signature or Merkle root. Fixing that necessarily changes the bytes.
+
+**This is a hard wire-format break.** A node running 0.0.1 and a node running
+an earlier build cannot participate in the same network: they compute
+different block digests, so PRE-PREPARE is rejected as a digest mismatch;
+different vote payloads, so every signature verification fails; and different
+state roots, so even agreement on a block would leave them on divergent
+chains. There is no compatibility mode and no negotiation. Upgrade every node
+together, from a fresh genesis.
+
+Persisted state must also be discarded. Account records written by an earlier
+build lack the account domain tag and `decodeAccount` now rejects them
+(`RaijinError: Not an account encoding`), and every state root derived from
+them would differ regardless.
+
+### Formats that moved
+
+| Format | Before | After | Consequence |
+| --- | --- | --- | --- |
+| PBFT vote signatures (`voteDigest`) | signature over the bare block digest | `H(phase tag ‖ 0x00 ‖ view ‖ sequence ‖ digest)` | every PREPARE/COMMIT/VIEW-CHANGE/PRE-PREPARE signature changes; old signatures verify nowhere |
+| `merkleRoot` | plain pairwise hashing, last leaf duplicated on odd levels, single leaf returned unhashed | `0x00` leaf / `0x01` node domain tags, odd level promotes, empty list is `H(0x00)` | every `txRoot` and `receiptRoot` changes |
+| Block header encoding (`encodeBlockHeader`, new export) | ad-hoc concatenation inside PBFT | domain tag `0x05`, length-prefixed roots and proposer, range-checked `u64` fields | the consensus digest changes; the header layout now has exactly one definition, shared by PBFT and `blockHash` |
+| `parentHash` semantics | the parent's **state root** | the parent's **block hash** — `blockHash(parent)` = `H(encodeBlockHeader(parent.header))` (new export) | chain linkage now commits to the parent's transactions, proposer, timestamp and roots, not only to its post-state |
+| `encodeTx` | raw concatenation; `to: null` encoded like `to: new Uint8Array(0)` | domain tag `0x01`; optional recipient carries a presence byte | the signed bytes change — every transaction signed by an earlier SDK is invalid |
+| `encodeTxSigned` | `encodeTx ‖ signature` | domain tag `0x02` ahead of the same | transaction hashes change: `txRoot` leaves, mempool dedup keys, and the `txHash` on every receipt |
+| `encodeAccount` / `decodeAccount` | three LEB128 fields | domain tag `0x03` ahead of them; the decoder rejects any other tag | stored account records are not readable by the other version, in either direction |
+| `encodeReceipt` | raw concatenation; absent and empty `revertReason` identical | domain tag `0x04`; `revertReason` carries a presence byte | `receiptRoot` changes |
+| `InMemoryStateStore.root()` | `H(hex(key₀) ‖ value₀ ‖ hex(key₁) ‖ value₁ ‖ …)`, entries ordered by `localeCompare` | `merkleRoot` over `H(encodeStateEntry(key, value))` per entry, ordered by key bytes | every `stateRoot` changes; a `StateStore` implemented elsewhere must use the exported `encodeStateEntry` to agree |
+
+### Also breaking, though not a byte format
+
+- `BlockProducer#advance(block)` returns `Promise<void>` rather than `void` —
+  it hashes the parent header. Callers must `await` it.
+- `Wallet` keys are non-extractable by default, and `chainId` is required
+  when building a transaction rather than defaulting. (`chainId` was already
+  part of `encodeTx`'s bytes; what changed is that the SDK no longer picks
+  one for you.)
+- `CelestiaDA` refuses to send an auth token over cleartext HTTP.
+
+### Checklist for operators
+
+1. Stop every node. A partial upgrade is worse than a stopped network: the
+   old and new halves will both consider the other's blocks invalid.
+2. Discard persisted state and start from a fresh genesis. There is no
+   state-format converter, and account records will not decode.
+3. Rebuild and redeploy every node, plus any client that signs transactions —
+   an old client's signatures will be rejected by an upgraded validator.
+4. Re-seed genesis balances with the current `encodeAccount`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,10 +1,14 @@
 # Migration notes
 
-## Unreleased → 0.0.1 — every hashed and signed format changed
+## 0.0.0 → 0.0.1 — every hashed and signed format changed
 
 The security work leading to 0.0.1 fixed a family of encoding bugs in which
 two different structures could produce the same bytes, and therefore the same
 hash, signature or Merkle root. Fixing that necessarily changes the bytes.
+
+0.0.0 is the baseline throughout: every unscoped release before it
+(`raijin-core@0.0.1`, `raijin-consensus@0.0.3`, and their siblings) has the
+same formats and the same defects, so everything here applies to those too.
 
 **This is a hard wire-format break.** A node running 0.0.1 and a node running
 an earlier build cannot participate in the same network: they compute
@@ -14,10 +18,12 @@ state roots, so even agreement on a block would leave them on divergent
 chains. There is no compatibility mode and no negotiation. Upgrade every node
 together, from a fresh genesis.
 
-Persisted state must also be discarded. Account records written by an earlier
-build lack the account domain tag and `decodeAccount` now rejects them
-(`RaijinError: Not an account encoding`), and every state root derived from
-them would differ regardless.
+Persisted state must also be discarded, keys as well as values. Account
+records written by an earlier build lack the account domain tag and
+`decodeAccount` now rejects them (`RaijinError: Not an account encoding`), and
+they are filed under the old un-prefixed key layout, so an upgraded node would
+not look them up in the first place. Every state root derived from them would
+differ regardless.
 
 ### Formats that moved
 
@@ -32,6 +38,7 @@ them would differ regardless.
 | `encodeTxSigned` | `encodeTx ‖ signature` | domain tag `0x02` ahead of the same | transaction hashes change: `txRoot` leaves, mempool dedup keys, and the `txHash` on every receipt |
 | `encodeAccount` / `decodeAccount` | three LEB128 fields | domain tag `0x03` ahead of them; the decoder rejects any other tag | stored account records are not readable by the other version, in either direction |
 | `encodeReceipt` | raw concatenation; absent and empty `revertReason` identical | domain tag `0x04`; `revertReason` carries a presence byte | `receiptRoot` changes |
+| State keys (`stateKey`, new export; `accountKey`, new export) | `namespace ‖ id`, concatenated raw | `0x07 ‖ len(namespace) ‖ namespace ‖ len(id) ‖ id` | every key in the store changes, and so does every state root derived from them. Anything that wrote account keys by hand — genesis funding, fixtures, state sync — must switch to `accountKey(address)` |
 | `InMemoryStateStore.root()` | `H(hex(key₀) ‖ value₀ ‖ hex(key₁) ‖ value₁ ‖ …)`, entries ordered by `localeCompare` | `merkleRoot` over `H(encodeStateEntry(key, value))` per entry, ordered by key bytes | every `stateRoot` changes; a `StateStore` implemented elsewhere must use the exported `encodeStateEntry` to agree |
 
 ### Also breaking, though not a byte format
@@ -49,6 +56,15 @@ them would differ regardless.
 - **`ValidatorSet` gained `epoch()`**, an async digest of the exact membership
   and order. It is the epoch every vote is signed against; a `ValidatorSet`
   replacement or wrapper must provide it.
+- **State keys are built by `accountKey`/`stateKey`, exported from
+  `@johnhenry/raijin-core`.** The old layout — a namespace prefix concatenated
+  onto an id — was unambiguous only by coincidence: the shipped namespaces
+  happen to be prefix-free and every id in use happens to be a fixed-width
+  32-byte key. Nothing enforced either. The layout was also duplicated by hand
+  at seven call sites, which is what made it fragile. Replace
+  `new Uint8Array([...encoder.encode('account:'), ...address])` with
+  `accountKey(address)`; `StateNamespace` holds the other namespace prefixes
+  for `stateKey(namespace, id)`.
 - `BlockProducer#advance(block)` returns `Promise<void>` rather than `void` —
   it hashes the parent header. Callers must `await` it.
 - `Wallet` keys are non-extractable by default — `Wallet.generate()` **and
@@ -66,6 +82,37 @@ them would differ regardless.
   explicit codec for environments where the optional fflate import does not
   resolve.
 
+### Also breaking, from the earlier security pass
+
+These landed before the encoding work and are also new to anyone on 0.0.0.
+
+- **`PBFTConfig.verify` is required** — a `SignatureVerifier` used to check
+  every PRE-PREPARE, PREPARE, COMMIT and VIEW-CHANGE. There was previously no
+  such field, because votes were never verified. `ValidatorNode` supplies it
+  from `identity.verify`, which means that one verifier now authenticates
+  consensus votes as well as transactions: a stub that returns `true`
+  unconditionally is no longer merely permissive about transactions, it
+  disables vote authentication.
+- **A receipt's `txHash` is the hash of the *signed* encoding.** It was
+  `hash(encodeTx(tx))` (unsigned); it is now `hash(encodeTxSigned(tx))`, the
+  same identifier used for `txRoot` leaves and mempool keys — one transaction
+  id instead of two. Code correlating submissions with receipts by
+  `hash(encodeTx(tx))` will stop matching. (On top of that, `encodeTxSigned`'s
+  own bytes changed in this release, per the table above.)
+- **`ValidatorNode` runs the real mempool.** `@johnhenry/raijin-validator` no
+  longer defines its own FIFO `Mempool`; it re-exports
+  `@johnhenry/raijin-mempool`'s. Consequences: `submitTransaction()` now
+  **throws** on an invalid signature or a duplicate sender+nonce instead of
+  accepting the transaction and reverting it a block later, ordering is by fee
+  rather than arrival, and a full pool evicts the lowest-fee entry instead of
+  throwing `'Mempool full'`. If you imported `Mempool` from the validator
+  package you now get a different class with a different API (`submit`, not
+  `add`).
+- **Block headers carry real roots.** `stateRoot` and `receiptRoot` are filled
+  in after execution rather than left zero-filled forever. Anything that
+  asserted those fields were zero, or used a header's zeroed state root as an
+  identifier, changes behaviour.
+
 ### Checklist for operators
 
 1. Stop every node. A partial upgrade is worse than a stopped network: the
@@ -77,4 +124,5 @@ them would differ regardless.
    Give every node the same `chainId`, and give two different deployments
    two different ones: that is what now stops votes from one being counted
    by the other.
-4. Re-seed genesis balances with the current `encodeAccount`.
+4. Re-seed genesis balances with the current `encodeAccount`, written under
+   the key `accountKey(address)` returns.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,7 +23,8 @@ them would differ regardless.
 
 | Format | Before | After | Consequence |
 | --- | --- | --- | --- |
-| PBFT vote signatures (`voteDigest`) | signature over the bare block digest | `H(phase tag ‖ 0x00 ‖ view ‖ sequence ‖ digest)` | every PREPARE/COMMIT/VIEW-CHANGE/PRE-PREPARE signature changes; old signatures verify nowhere |
+| PBFT vote signatures (`voteDigest`) | signature over the bare block digest | `H(phase tag ‖ 0x00 ‖ chainId ‖ epoch ‖ view ‖ sequence ‖ digest)`, tags bumped `v1` → `v2`, integers LEB128, `epoch`/`digest` length-prefixed | every PREPARE/COMMIT/VIEW-CHANGE/PRE-PREPARE signature changes; old signatures verify nowhere. A vote is now scoped to one chain and one validator set as well as one phase and round |
+| DA compressed frame (`@johnhenry/raijin-da` `encode`/`decode`) | `"RJC" ‖ deflate(data)` | `"RJC" ‖ LEB128(decompressed length) ‖ deflate(data)` | a compressed blob written by an earlier build has no length header and is rejected; `decode()` refuses anything over `maxDecompressedSize` (16 MiB by default) |
 | `merkleRoot` | plain pairwise hashing, last leaf duplicated on odd levels, single leaf returned unhashed | `0x00` leaf / `0x01` node domain tags, odd level promotes, empty list is `H(0x00)` | every `txRoot` and `receiptRoot` changes |
 | Block header encoding (`encodeBlockHeader`, new export) | ad-hoc concatenation inside PBFT | domain tag `0x05`, length-prefixed roots and proposer, range-checked `u64` fields | the consensus digest changes; the header layout now has exactly one definition, shared by PBFT and `blockHash` |
 | `parentHash` semantics | the parent's **state root** | the parent's **block hash** — `blockHash(parent)` = `H(encodeBlockHeader(parent.header))` (new export) | chain linkage now commits to the parent's transactions, proposer, timestamp and roots, not only to its post-state |
@@ -35,13 +36,35 @@ them would differ regardless.
 
 ### Also breaking, though not a byte format
 
+- **`voteDigest()` takes one object, not five positional arguments.**
+  `voteDigest(phase, view, sequence, digest)` becomes
+  `voteDigest({ phase, chainId, epoch, view, sequence, digest })`. Four of the
+  six fields are bigints or byte strings of the same shape, so a positional
+  call with two more of them was a transposition waiting to happen — and a
+  transposed pair signs a valid-looking signature over the wrong scope.
+- **`PBFTConfig.chainId` and `ValidatorNodeConfig.chainId` are required**, with
+  no default, for the reason `chainId` is required on a transaction: a default
+  is an id shared by every deployment that never chose one. `PBFTConsensus`
+  throws `TypeError` if it is missing.
+- **`ValidatorSet` gained `epoch()`**, an async digest of the exact membership
+  and order. It is the epoch every vote is signed against; a `ValidatorSet`
+  replacement or wrapper must provide it.
 - `BlockProducer#advance(block)` returns `Promise<void>` rather than `void` —
   it hashes the parent header. Callers must `await` it.
-- `Wallet` keys are non-extractable by default, and `chainId` is required
-  when building a transaction rather than defaulting. (`chainId` was already
-  part of `encodeTx`'s bytes; what changed is that the SDK no longer picks
-  one for you.)
+- `Wallet` keys are non-extractable by default — `Wallet.generate()` **and
+  now `Wallet.fromKey()`**, which hardcoded `extractable: true` and is the
+  path a persisted key comes back through. Pass `{ extractable: true }` at the
+  call site if the key genuinely has to be exported again.
+- `chainId` is required when building a transaction rather than defaulting.
+  (`chainId` was already part of `encodeTx`'s bytes; what changed is that the
+  SDK no longer picks one for you.)
 - `CelestiaDA` refuses to send an auth token over cleartext HTTP.
+- `decode()` in `@johnhenry/raijin-da` caps decompressed output at
+  `MAX_DECOMPRESSED_SIZE` (16 MiB) and rejects with `DASizeLimitError` /
+  `DADecodeError` rather than propagating whatever the compression library
+  threw. `encode(data, { deflate })` and `decode(data, { inflate })` accept an
+  explicit codec for environments where the optional fflate import does not
+  resolve.
 
 ### Checklist for operators
 
@@ -51,4 +74,7 @@ them would differ regardless.
    state-format converter, and account records will not decode.
 3. Rebuild and redeploy every node, plus any client that signs transactions —
    an old client's signatures will be rejected by an upgraded validator.
+   Give every node the same `chainId`, and give two different deployments
+   two different ones: that is what now stops votes from one being counted
+   by the other.
 4. Re-seed genesis balances with the current `encodeAccount`.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,16 @@ Think of it as the OP Stack, but for browsers.
 
 > **Provenance:** the six publishable packages above were previously
 > published unscoped (`raijin-core`, `raijin-consensus`, etc.) and now live
-> under the `@johnhenry` npm scope, restarting at `0.0.0`. See
+> under the `@johnhenry` npm scope, where they restarted at `0.0.0`. See
 > [CHANGELOG.md](CHANGELOG.md) for exact prior versions per package.
+
+> **If you are on `0.0.0`, upgrade.** `0.0.1` is the first release of these
+> packages that is safe to run: `0.0.0` and every unscoped version before it
+> finalize blocks on an unsafe quorum, collect consensus vote signatures
+> without verifying them, and derive block, state and Merkle roots from
+> encodings that two different structures can share. `0.0.1` is a hard wire-
+> format break with no compatibility mode — see [CHANGELOG.md](CHANGELOG.md)
+> and [MIGRATION.md](MIGRATION.md).
 
 ## Quick Start
 
@@ -92,12 +100,18 @@ What it provides:
 
 Why it stays unpublished: it reaches into `../../consensus/test/helpers.ts`
 for its mock network/timer (a path that only exists in this repo), and its
-multi-node tests are timing-sensitive by nature — the 11 harness tests are
+multi-node tests are timing-sensitive by nature — the 25 harness tests are
 known to be flaky under load, which is acceptable for internal scenario
-testing but not something to ship. The 123 tests across the six publishable
+testing but not something to ship. The 229 tests across the six publishable
 packages are deterministic; CI's example smoke step is also restricted to
 single-node scenarios for the same reason (see
 [examples/README.md](examples/README.md)).
+
+The harness also carries the Byzantine scenarios: an equivocating proposer
+that sends two different blocks for one sequence, and votes replayed across
+phases. Both were proven non-vacuous by injection — restoring the old
+`2f+1` quorum produces a real fork across honest replicas, and unbinding a
+vote's phase lets a block finalize on a manufactured commit quorum.
 
 ## Design Principles
 

--- a/examples/02-state-machine.mjs
+++ b/examples/02-state-machine.mjs
@@ -10,6 +10,7 @@
  */
 import assert from 'node:assert/strict'
 import {
+  accountKey,
   StateMachine,
   InMemoryStateStore,
   TransactionType,
@@ -28,10 +29,9 @@ const alice = new Uint8Array(32).fill(1)
 const bob = new Uint8Array(32).fill(2)
 
 // Fund alice directly in the store (genesis-style). Account state lives
-// under the 'account:' namespace prefix.
-const prefix = new TextEncoder().encode('account:')
-const aliceKey = new Uint8Array([...prefix, ...alice])
-await store.put(aliceKey, encodeAccount({ balance: 1000n, nonce: 0n, reputation: 0n }))
+// under the 'account:' namespace; `accountKey` builds the canonical key
+// bytes, which are hashed into the state root — don't hand-roll them.
+await store.put(accountKey(alice), encodeAccount({ balance: 1000n, nonce: 0n, reputation: 0n }))
 
 function transfer(from, to, value, nonce) {
   return {

--- a/examples/05-consensus-round.mjs
+++ b/examples/05-consensus-round.mjs
@@ -39,6 +39,7 @@ const manualTimer = { set: () => ({}), clear: () => {} }
 
 const consensus = new PBFTConsensus({
   identity: me,
+  chainId: 1n, // required: votes are signed against it, so there is no default
   validators,
   transport,
   timer: manualTimer,

--- a/examples/05-consensus-round.mjs
+++ b/examples/05-consensus-round.mjs
@@ -2,9 +2,12 @@
  * 05 — PBFT quorum math and a single-validator consensus round
  *      (@johnhenry/raijin-consensus)
  *
- * First: the quorum table. quorum = 2f+1 with f = floor((n-1)/3), so with
- * 1, 2, or 3 validators f = 0 and quorum = 1 — a single node finalizes
- * alone. Byzantine fault tolerance only starts at n = 4.
+ * First: the quorum table. quorum = n - f with f = floor((n-1)/3). At the
+ * canonical sizes (n = 3f+1: 1, 4, 7, ...) that equals 2f+1; everywhere
+ * else it is strictly larger, because 2f+1 is only safe at those sizes —
+ * at n = 2 or 3 it degenerates to quorum 1, letting a single node finalize
+ * alone. Only n = 1 has quorum 1 now. Byzantine fault *tolerance* still
+ * only starts at n = 4, where f first becomes non-zero.
  *
  * Then: a full propose → pre-prepare → prepare → commit → finalize round
  * with one validator (quorum 1), driven entirely in-process. Multi-node
@@ -23,7 +26,16 @@ for (let n = 1; n <= 7; n++) {
     Array.from({ length: n }, (_, i) => new Uint8Array(32).fill(i + 1)),
   )
   console.log(String(n).padStart(2), '|', String(set.maxFaults).padStart(9), '|', set.quorumSize())
+  // Safety needs any two quorums to share an honest node: 2q - n >= f + 1.
+  assert.ok(2 * set.quorumSize() - n >= set.maxFaults + 1, `quorum unsafe at n=${n}`)
+  assert.equal(set.quorumSize(), n - set.maxFaults)
 }
+// Only a one-node set can finalize on one vote.
+assert.equal(new ValidatorSet([new Uint8Array(32).fill(1)]).quorumSize(), 1)
+assert.equal(
+  new ValidatorSet([1, 2, 3].map((i) => new Uint8Array(32).fill(i))).quorumSize(),
+  3,
+)
 
 // ── Single-validator round ────────────────────────────────────────────
 const me = new Uint8Array(32).fill(7)

--- a/examples/06-validator-lifecycle.mjs
+++ b/examples/06-validator-lifecycle.mjs
@@ -10,6 +10,7 @@
  */
 import assert from 'node:assert/strict'
 import {
+  accountKey,
   InMemoryStateStore,
   TransactionType,
   encodeAccount,
@@ -22,9 +23,8 @@ const bob = new Uint8Array(32).fill(2)
 
 // Fund alice at genesis
 const store = new InMemoryStateStore()
-const prefix = new TextEncoder().encode('account:')
 await store.put(
-  new Uint8Array([...prefix, ...alice]),
+  accountKey(alice),
   encodeAccount({ balance: 10_000n, nonce: 0n, reputation: 0n }),
 )
 

--- a/examples/06-validator-lifecycle.mjs
+++ b/examples/06-validator-lifecycle.mjs
@@ -29,6 +29,7 @@ await store.put(
 )
 
 const node = new ValidatorNode({
+  chainId: 1n,
   identity: {
     publicKey: alice,
     sign: async () => new Uint8Array(64), // consensus-message signer

--- a/examples/07-sdk-end-to-end.mjs
+++ b/examples/07-sdk-end-to-end.mjs
@@ -10,6 +10,7 @@
  */
 import assert from 'node:assert/strict'
 import {
+  accountKey,
   InMemoryStateStore,
   encodeAccount,
   encodeTxSigned,
@@ -41,9 +42,8 @@ const merchant = new Uint8Array(32).fill(9)
 
 // ── One in-process validator node ─────────────────────────────────────
 const store = new InMemoryStateStore()
-const prefix = new TextEncoder().encode('account:')
 await store.put(
-  new Uint8Array([...prefix, ...userWallet.publicKey]),
+  accountKey(userWallet.publicKey),
   encodeAccount({ balance: 1_000n, nonce: 0n, reputation: 0n }),
 )
 

--- a/examples/07-sdk-end-to-end.mjs
+++ b/examples/07-sdk-end-to-end.mjs
@@ -48,6 +48,7 @@ await store.put(
 )
 
 const node = new ValidatorNode({
+  chainId: 1n,
   identity: {
     publicKey: validatorWallet.publicKey,
     sign: (msg) => validatorWallet.sign(msg),

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,13 +15,13 @@ Node ≥ 24 (example 07 uses Web Crypto Ed25519).
 
 | # | File | Shows |
 | --- | --- | --- |
-| 01 | `01-hashing-merkle.mjs` | `@johnhenry/raijin-core` hashing: SHA-256, Merkle roots (odd-leaf padding, order sensitivity), hex round-trips |
-| 02 | `02-state-machine.mjs` | `StateMachine` + `InMemoryStateStore`: genesis funding, a successful transfer, insufficient-balance and nonce-mismatch revert receipts |
+| 01 | `01-hashing-merkle.mjs` | `@johnhenry/raijin-core` hashing: SHA-256, Merkle roots (leaf/node domain tags, odd levels promoted rather than duplicated, order sensitivity), hex round-trips |
+| 02 | `02-state-machine.mjs` | `StateMachine` + `InMemoryStateStore`: genesis funding via `accountKey`, a successful transfer, insufficient-balance and nonce-mismatch revert receipts |
 | 03 | `03-mempool-ordering.mjs` | `@johnhenry/raijin-mempool`: the 8-byte fee convention, fee-descending ordering, strict-inequality eviction, duplicate rejection |
-| 04 | `04-da-local.mjs` | `@johnhenry/raijin-da`: `encode`/`decode` magic headers, `LocalDA` submit/retrieve/verify, what commitment verification does and doesn't prove |
-| 05 | `05-consensus-round.mjs` | `@johnhenry/raijin-consensus`: the quorum table (n=1..7), then a full single-validator PBFT round from `propose()` to finalization |
+| 04 | `04-da-local.mjs` | `@johnhenry/raijin-da`: `encode`/`decode` frame headers, `LocalDA` submit/retrieve/verify, what commitment verification does and doesn't prove |
+| 05 | `05-consensus-round.mjs` | `@johnhenry/raijin-consensus`: the `n - f` quorum table (n=1..7), asserted safe at every size, then a full single-validator PBFT round from `propose()` to finalization |
 | 06 | `06-validator-lifecycle.mjs` | `@johnhenry/raijin-validator`: a one-node chain with real timers — submit, block production, finalization, mempool pruning, clean stop |
-| 07 | `07-sdk-end-to-end.mjs` | `@johnhenry/raijin-sdk`: `Wallet` (real Ed25519) → `RaijinClient` → in-process `ValidatorNode`, including a tampered-tx revert |
+| 07 | `07-sdk-end-to-end.mjs` | `@johnhenry/raijin-sdk`: `Wallet` (real Ed25519) → `RaijinClient` → in-process `ValidatorNode`, including a tampered transaction rejected by the mempool before it can reach a block |
 
 Run one:
 
@@ -37,6 +37,6 @@ npm run examples
 
 ## Why every example is single-node
 
-All seven examples run one validator in one process, on purpose. Single-validator PBFT has quorum 1 (see example 05), so consensus completes deterministically with no cross-node timing — which makes these examples safe to run in CI as a smoke test (`npm run examples` is a CI step).
+All seven examples run one validator in one process, on purpose. At n = 1 the quorum is 1 (see example 05 — it is the only validator count where that holds), so consensus completes deterministically with no cross-node timing, which makes these examples safe to run in CI as a smoke test (`npm run examples` is a CI step).
 
 Multi-node scenarios (leader crashes, partitions, gossip convergence, membership churn) are exercised by the internal `raijin-test-harness` package instead. Those tests coordinate several nodes over a simulated network and are timing-sensitive — they are deliberately **excluded** from the examples loop and the CI smoke step so a scheduling hiccup can't fail an unrelated change. Run them directly with `npm run test -w raijin-test-harness` if you want them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2237,10 +2237,10 @@
     },
     "packages/consensus": {
       "name": "@johnhenry/raijin-consensus",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-core": "^0.0.0"
+        "@johnhenry/raijin-core": "^0.0.1"
       },
       "devDependencies": {
         "tsup": "^8",
@@ -2250,7 +2250,7 @@
     },
     "packages/core": {
       "name": "@johnhenry/raijin-core",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "tsup": "^8",
@@ -2260,10 +2260,10 @@
     },
     "packages/da": {
       "name": "@johnhenry/raijin-da",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-core": "^0.0.0"
+        "@johnhenry/raijin-core": "^0.0.1"
       },
       "devDependencies": {
         "tsup": "^8",
@@ -2281,10 +2281,10 @@
     },
     "packages/mempool": {
       "name": "@johnhenry/raijin-mempool",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-core": "^0.0.0"
+        "@johnhenry/raijin-core": "^0.0.1"
       },
       "devDependencies": {
         "tsup": "^8",
@@ -2294,10 +2294,10 @@
     },
     "packages/sdk": {
       "name": "@johnhenry/raijin-sdk",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-core": "^0.0.0"
+        "@johnhenry/raijin-core": "^0.0.1"
       },
       "devDependencies": {
         "tsup": "^8",
@@ -2309,9 +2309,9 @@
       "name": "raijin-test-harness",
       "version": "0.1.0",
       "dependencies": {
-        "@johnhenry/raijin-consensus": "^0.0.0",
-        "@johnhenry/raijin-core": "^0.0.0",
-        "@johnhenry/raijin-validator": "^0.0.0"
+        "@johnhenry/raijin-consensus": "^0.0.1",
+        "@johnhenry/raijin-core": "^0.0.1",
+        "@johnhenry/raijin-validator": "^0.0.1"
       },
       "devDependencies": {
         "typescript": "^5.7",
@@ -2320,12 +2320,12 @@
     },
     "packages/validator": {
       "name": "@johnhenry/raijin-validator",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-consensus": "^0.0.0",
-        "@johnhenry/raijin-core": "^0.0.0",
-        "@johnhenry/raijin-mempool": "^0.0.0"
+        "@johnhenry/raijin-consensus": "^0.0.1",
+        "@johnhenry/raijin-core": "^0.0.1",
+        "@johnhenry/raijin-mempool": "^0.0.1"
       },
       "devDependencies": {
         "tsup": "^8",

--- a/packages/consensus/README.md
+++ b/packages/consensus/README.md
@@ -2,7 +2,7 @@
 
 PBFT consensus and leader rotation for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
-Implements a simplified Practical Byzantine Fault Tolerance protocol: the leader broadcasts PRE-PREPARE with a proposed block, validators answer PREPARE, then COMMIT, and the block finalizes once `2f+1` commits are collected. View changes rotate the leader when it stops proposing. Transport and timers are injected, so the engine runs over WebRTC, WebSockets, or an in-memory bus, and tests can drive time deterministically.
+Implements a simplified Practical Byzantine Fault Tolerance protocol: the leader broadcasts PRE-PREPARE with a proposed block, validators answer PREPARE, then COMMIT, and the block finalizes once a quorum of `n - f` commits is collected. View changes rotate the leader when it stops proposing. Every vote is signed and verified against a payload that names the chain, the validator set, the phase, the view and the sequence, so no signature is reusable anywhere else. Transport and timers are injected, so the engine runs over WebRTC, WebSockets, or an in-memory bus, and tests can drive time deterministically.
 
 ## Install
 
@@ -12,34 +12,56 @@ npm install @johnhenry/raijin-consensus
 
 ## Quorum math — read this before choosing a validator count
 
-`quorumSize() = 2f + 1` with `f = floor((n - 1) / 3)`:
+`quorumSize() = n - f` with `f = floor((n - 1) / 3)`:
 
-| validators (n) | tolerated faults (f) | quorum |
-| --- | --- | --- |
-| 1–3 | 0 | **1** |
-| 4–6 | 1 | 3 |
-| 7–9 | 2 | 5 |
+| validators (n) | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| tolerated faults (f) | 0 | 0 | 0 | 1 | 1 | 1 | 2 | 2 | 2 | 3 |
+| quorum (q) | 1 | 2 | 3 | 3 | 4 | 5 | 5 | 6 | 7 | 7 |
 
-With 1, 2, or 3 validators, **a single node meets quorum and finalizes alone** — there is no Byzantine tolerance below `n = 4`. That's convenient for demos and fatal if you assumed otherwise.
+Safety needs any two quorums to overlap in at least one honest node — `2q - n >= f + 1`. `q = n - f` satisfies that at every `n`. At the canonical PBFT sizes (`n = 3f + 1`: 1, 4, 7, 10, …) it is exactly `2f + 1`; everywhere else it is strictly larger, which is the point. `q = 2f + 1` **is not safe off those sizes**, and at `n = 2` or `n = 3` it degenerates to `q = 1` — one node reaching its own PREPARE and COMMIT quorum and finalizing blocks alone. That is what this package used to do, and it does not any more.
+
+You still get no Byzantine *tolerance* below `n = 4` — with `f = 0` a single faulty node is one too many — but a faulty node can no longer finalize by itself: at `n = 3` it needs all three.
 
 Two more sharp edges:
 
-- **Messages are trusted from the transport.** The engine checks that `from` is in the validator set, but nothing verifies that the transport reported `from` honestly, and the signatures carried on COMMIT messages are collected, not verified. Authentication is your transport's job.
+- **`chainId` is required and has no default.** It is signed into every vote. A default would be an id shared by every deployment that never chose one, and votes would then replay verbatim between them (testnet into mainnet, a fork into its parent). `PBFTConsensus` throws `TypeError` if it is missing.
 - **The engine never builds blocks.** The leader's block timer fires into a no-op; something external (`BlockProducer` in `@johnhenry/raijin-validator`) must construct a block and call `propose()`.
+
+## What the engine authenticates, and what is still yours
+
+Earlier versions of this package collected vote signatures without checking them and told you that authentication was your transport's job. It isn't any more. Be precise about the new line, because the half that is still yours has not moved.
+
+**The engine now guarantees, on every PRE-PREPARE, PREPARE, COMMIT and VIEW-CHANGE it acts on:**
+
+- **The signature is verified** against the claimed sender, through the `verify` (`SignatureVerifier`) you inject. A message that fails is dropped before it reaches any counter. `verify` is a required config field — there is no unverified mode to fall back into.
+- **The signature is bound to its scope.** A vote is signed over `voteDigest({ phase, chainId, epoch, view, sequence, digest })`, so one signature authorizes exactly one phase, of one round, at one sequence, on one chain, under one validator set. A PREPARE is not a COMMIT. A vote from view 4 is not a vote in view 5. A testnet vote is not a mainnet vote. A vote cast before a membership change is not a vote after it — `epoch` is a digest of the exact set and order, so a removed validator's still-valid signatures stop counting toward the quorum of the set that removed it.
+- **`chainId` and `epoch` come from this node, never from the message.** A peer cannot tell you which chain or which set its vote should count under; it can only produce a signature that matches your scope or does not.
+- **A sender counts once.** VIEW-CHANGE messages are deduplicated by sender, and PREPARE/COMMIT are collected into per-digest sets keyed by validator, so re-broadcasting cannot manufacture a quorum from one node.
+- **Views only move forward.** A recorded VIEW-CHANGE quorum stays valid forever, so replaying one would otherwise rewind the view and clear every in-flight round indefinitely. `newView <= currentView` is dropped, for both VIEW-CHANGE and NEW-VIEW.
+
+**Still yours:**
+
+- **Delivery.** The engine never retries, never orders, never detects a dropped message. If your transport loses PREPAREs, rounds simply time out into view changes. Liveness is a transport property; only safety is defended here.
+- **Sybil resistance and the membership list itself.** `from` is checked for membership in the `ValidatorSet` you supply, and *that* is what the signature then proves. The engine has no opinion on who belongs in the set or how it changes — it will faithfully authenticate a vote from a validator you should never have admitted.
+- **Confidentiality and DoS.** Nothing here is encrypted, and signature verification happens per message, so an unauthenticated peer that can reach `onMessage` can still make you do work. Rate-limit at the transport.
+- **The verifier's correctness.** `verify` is injected. An implementation that returns `true` unconditionally reinstates every hole listed above; `ed25519Verifier` from `@johnhenry/raijin-core` is the real one.
 
 ## Quick start
 
 ```js
-import { StateMachine, InMemoryStateStore } from '@johnhenry/raijin-core'
+import { StateMachine, InMemoryStateStore, ed25519Verifier } from '@johnhenry/raijin-core'
 import { PBFTConsensus, ValidatorSet } from '@johnhenry/raijin-consensus'
 
 const consensus = new PBFTConsensus({
   identity: myPublicKey,             // 32 bytes
+  chainId: 42n,                      // required, no default — see above
   validators: new ValidatorSet([myPublicKey, peerA, peerB, peerC]),
   transport,                         // NetworkTransport — your WebRTC/WebSocket bridge
   timer: { set: (ms, cb) => setTimeout(cb, ms), clear: clearTimeout },
   stateMachine: new StateMachine(new InMemoryStateStore(), verifier),
   sign: (msg) => wallet.sign(msg),
+  verify: ed25519Verifier,           // required — every vote is checked with this
   blockTime: 2000,                   // default 2000
   viewTimeout: 10000,                // default 10000
 })
@@ -57,7 +79,7 @@ if (consensus.isLeader) await consensus.propose(block)
 
 ### `PBFTConsensus`
 
-`new PBFTConsensus(config: PBFTConfig)` — config fields: `identity`, `validators`, `transport`, `timer`, `stateMachine`, `sign`, optional `blockTime` (ms, default 2000), optional `viewTimeout` (ms, default 10000).
+`new PBFTConsensus(config: PBFTConfig)` — config fields: `identity`, `chainId` (**required**, `bigint`), `validators`, `transport`, `timer`, `stateMachine`, `sign`, `verify` (**required**, `SignatureVerifier`), optional `blockTime` (ms, default 2000), optional `viewTimeout` (ms, default 10000).
 
 | Member | Purpose |
 | --- | --- |
@@ -70,15 +92,18 @@ if (consensus.isLeader) await consensus.propose(block)
 | `isLeader` / `currentLeader` | Leader for the current view (round-robin over the validator set). |
 | `running` | Whether `start()` has been called. |
 
-View changes: if the view timer expires without progress, the node broadcasts `view-change` for `view + 1`; once `quorumSize()` view-change messages accumulate, everyone rotates, clears in-flight rounds, and the new leader takes over.
+View changes: if the view timer expires without progress, the node broadcasts `view-change` for `view + 1`; once `quorumSize()` validly-signed view-change messages from *distinct* senders accumulate, everyone rotates, clears in-flight rounds, and the new leader takes over. A view change only ever moves forward — a message for a view at or below the current one is dropped, so a replayed quorum cannot rewind the node.
+
+Carry-over is partial: a new leader is prevented from proposing a *conflicting* block at a sequence that already reached a PREPARE quorum, but the original block is not automatically re-proposed. Full prepared-certificate carry-over is tracked as follow-up work.
 
 ### `ValidatorSet`
 
 `new ValidatorSet(validators?: Uint8Array[])` — ordered set of 32-byte public keys.
 
 - `add(pubkey)` / `remove(pubkey)` / `has(pubkey)` — membership; `add` returns `false` on duplicates.
+- `epoch(): Promise<Uint8Array>` — a 32-byte digest of this exact set, in this exact order. Every vote signature covers it, which is what stops votes crossing a membership change. It is a digest rather than a counter on purpose: two nodes that applied *different* changes would still agree on "epoch 2" and go on counting each other's votes, whereas disagreeing about who is in the set makes them disagree about the epoch. Order is included because `leaderForView` picks by index, so the same members in a different order are genuinely a different set. Memoized, and invalidated by `add`/`remove`. A `ValidatorSet` replacement or wrapper must provide it.
 - `leaderForView(view)` — deterministic round-robin: `validators[view % n]`. Throws on an empty set.
-- `quorumSize()` / `maxFaults` — the math above.
+- `quorumSize()` / `maxFaults` — the math above (`n - f` and `floor((n - 1) / 3)`).
 - `size` / `all()` / `at(index)` — inspection.
 
 Every node must construct its `ValidatorSet` with the **same keys in the same order**, or leader election disagrees and nothing finalizes.
@@ -86,6 +111,18 @@ Every node must construct its `ValidatorSet` with the **same keys in the same or
 ### Types
 
 `PBFTConfig`, `PBFTPhase`, `NetworkTransport` (`broadcast`/`send`/`onMessage`), `ConsensusTimer` + `TimerHandle` (`set`/`clear` — injectable for deterministic tests), and the message union `ConsensusMessage` = `PrePrepareMessage | PrepareMessage | CommitMessage | ViewChangeMessage | NewViewMessage`.
+
+### `voteDigest(vote: Vote)` / `NO_BLOCK_DIGEST`
+
+The bytes a validator signs for one vote, exported so a transport, relay or test can construct and check a vote without re-deriving the layout — there is one definition and this is it.
+
+```ts
+voteDigest({ phase, chainId, epoch, view, sequence, digest }): Promise<Uint8Array>
+```
+
+`H(tag ‖ 0x00 ‖ chainId ‖ epoch ‖ view ‖ sequence ‖ digest)`, integers LEB128, `epoch` and `digest` length-prefixed, so every field is self-delimiting and no two distinct votes share an input. `phase` is a `VotePhase` (`'pre-prepare' | 'prepare' | 'commit' | 'view-change'`) selecting the domain tag. Use `NO_BLOCK_DIGEST` (32 zero bytes) as the `digest` for VIEW-CHANGE, which commits to no block.
+
+It takes one object rather than positional arguments deliberately: four of the six fields are bigints or byte strings of the same shape, and a transposed pair would silently sign a valid-looking signature over the wrong scope.
 
 If your transport serializes to JSON, remember consensus messages carry `bigint`s and `Uint8Array`s — you need a replacer/reviver pair (see `test/helpers.ts` in the repo for a working one).
 

--- a/packages/consensus/package.json
+++ b/packages/consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-consensus",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "PBFT consensus and leader rotation for the Raijin mesh rollup",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1"
   },
   "devDependencies": {
     "typescript": "^5.7",

--- a/packages/consensus/src/index.ts
+++ b/packages/consensus/src/index.ts
@@ -27,4 +27,4 @@ export type {
 export { PBFTPhase } from './types.js'
 
 export { voteDigest, NO_BLOCK_DIGEST } from './vote.js'
-export type { VotePhase } from './vote.js'
+export type { VotePhase, Vote } from './vote.js'

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Block, StateMachine, TransactionReceipt, SignatureVerifier } from '@johnhenry/raijin-core'
-import { hash, merkleRoot, encodeReceipt, equal, toHex } from '@johnhenry/raijin-core'
+import { hash, merkleRoot, encodeReceipt, encodeBlockHeader, equal, toHex } from '@johnhenry/raijin-core'
 import { ValidatorSet } from './validator-set.js'
 import { voteDigest, NO_BLOCK_DIGEST, type VotePhase } from './vote.js'
 import type {
@@ -420,8 +420,10 @@ export class PBFTConsensus {
     // executed the block, fill in the real values. This doesn't change the
     // already-agreed digest (nothing re-verifies it after this point); it
     // only affects the finalized block object used for chain linkage
-    // (BlockProducer#advance reads `header.stateRoot` as the next block's
-    // parentHash) and for fork/convergence detection in the test harness.
+    // (BlockProducer#advance hashes this completed header with `blockHash`
+    // to get the next block's parentHash, so the link covers the executed
+    // result as well as the proposal) and for fork/convergence detection in
+    // the test harness.
     this.#pendingBlock.header.stateRoot = await this.#stateMachine.stateRoot()
     this.#pendingBlock.header.receiptRoot = await this.#computeReceiptRoot(receipts)
 
@@ -528,34 +530,11 @@ export class PBFTConsensus {
 
   // ── Helpers ─────────────────────────────────────────────────────────
 
+  /** Header bytes the consensus digest is taken over. Shared with
+   *  `blockHash`, so the bytes nodes agree on and the bytes that link a block
+   *  to its child are the same bytes. */
   #serializeBlockHeader(block: Block): Uint8Array {
-    // Deterministic serialization of block header fields
-    const parts: Uint8Array[] = [
-      this.#bigintToBytes(block.header.number),
-      block.header.parentHash,
-      block.header.stateRoot,
-      block.header.txRoot,
-      block.header.receiptRoot,
-      this.#bigintToBytes(BigInt(block.header.timestamp)),
-      block.header.proposer,
-    ]
-    const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-    const result = new Uint8Array(totalLen)
-    let pos = 0
-    for (const part of parts) {
-      result.set(part, pos)
-      pos += part.length
-    }
-    return result
-  }
-
-  #bigintToBytes(value: bigint): Uint8Array {
-    const hex = value.toString(16).padStart(16, '0')
-    const bytes = new Uint8Array(8)
-    for (let i = 0; i < 8; i++) {
-      bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-    }
-    return bytes
+    return encodeBlockHeader(block.header)
   }
 
   /** Sign one vote over its domain-separated payload (see `voteDigest`). */

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -32,6 +32,15 @@ import { PBFTPhase } from './types.js'
 export interface PBFTConfig {
   /** This node's public key. */
   identity: Uint8Array
+  /**
+   * Chain identifier — which deployment this node's votes are about.
+   *
+   * Required, with no default, for the same reason `chainId` is required on
+   * a transaction: a default is an id that every deployment which never
+   * chose one shares, and votes would then replay verbatim between them.
+   * Every vote signature covers it (see `voteDigest`).
+   */
+  chainId: bigint
   /** The validator set. */
   validators: ValidatorSet
   /** Network transport for sending/receiving messages. */
@@ -53,8 +62,9 @@ export interface PBFTConfig {
    * `#handleMessage` could forge votes on behalf of any validator.
    *
    * Every vote is signed over a domain-separated payload (see `voteDigest`)
-   * that names the phase, the view and the sequence, so no signature is
-   * reusable in another phase or another round.
+   * that names the chain, the validator-set epoch, the phase, the view and
+   * the sequence, so no signature is reusable in another phase, another
+   * round, another chain, or across a membership change.
    */
   verify: SignatureVerifier
 }
@@ -62,6 +72,7 @@ export interface PBFTConfig {
 export class PBFTConsensus {
   #identity: Uint8Array
   #identityHex: string
+  #chainId: bigint
   #validators: ValidatorSet
   #transport: NetworkTransport
   #timer: ConsensusTimer
@@ -103,8 +114,16 @@ export class PBFTConsensus {
   #onViewChange: ((newView: bigint) => void)[] = []
 
   constructor(config: PBFTConfig) {
+    // Guard the JS callers the type system does not reach: an undefined
+    // chainId would otherwise be signed as a chain id of its own, and every
+    // node that forgot one would agree with every other node that forgot one.
+    if (typeof config.chainId !== 'bigint') {
+      throw new TypeError('PBFTConsensus: chainId is required and must be a bigint')
+    }
+
     this.#identity = config.identity
     this.#identityHex = toHex(config.identity)
+    this.#chainId = config.chainId
     this.#validators = config.validators
     this.#transport = config.transport
     this.#timer = config.timer
@@ -537,6 +556,30 @@ export class PBFTConsensus {
     return encodeBlockHeader(block.header)
   }
 
+  /**
+   * The bytes of one vote (see `voteDigest`).
+   *
+   * `chainId` and the validator-set `epoch` come from *this* node, never from
+   * the message. That is what makes them scope rather than metadata: a peer
+   * cannot tell us which chain or which set its vote should count under, it
+   * can only produce a signature that either matches ours or does not.
+   */
+  async #voteBytes(
+    phase: VotePhase,
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+  ): Promise<Uint8Array> {
+    return voteDigest({
+      phase,
+      chainId: this.#chainId,
+      epoch: await this.#validators.epoch(),
+      view,
+      sequence,
+      digest,
+    })
+  }
+
   /** Sign one vote over its domain-separated payload (see `voteDigest`). */
   async #signVote(
     phase: VotePhase,
@@ -544,7 +587,7 @@ export class PBFTConsensus {
     sequence: bigint,
     digest: Uint8Array,
   ): Promise<Uint8Array> {
-    return this.#sign(await voteDigest(phase, view, sequence, digest))
+    return this.#sign(await this.#voteBytes(phase, view, sequence, digest))
   }
 
   /** Verify one vote's signature against the claimed signer. */
@@ -556,6 +599,10 @@ export class PBFTConsensus {
     signature: Uint8Array,
     signer: Uint8Array,
   ): Promise<boolean> {
-    return this.#verify.verify(await voteDigest(phase, view, sequence, digest), signature, signer)
+    return this.#verify.verify(
+      await this.#voteBytes(phase, view, sequence, digest),
+      signature,
+      signer,
+    )
   }
 }

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -5,7 +5,7 @@
  * 1. Leader proposes a block (PRE-PREPARE)
  * 2. Validators acknowledge (PREPARE)
  * 3. Validators commit (COMMIT)
- * 4. Block is finalized when 2f+1 commits are collected
+ * 4. Block is finalized when a quorum of `n - f` commits is collected
  *
  * View changes handle leader failure: if the leader doesn't propose
  * within the timeout, validators request a view change to rotate
@@ -269,7 +269,7 @@ export class PBFTConsensus {
     if (!(await this.#verifyVote('pre-prepare', msg.view, msg.sequence, digest, msg.signature, from))) return
 
     // Partial view-change safety mitigation: if this sequence was already
-    // validly prepared (2f+1 PREPARE votes) at some prior view, refuse to
+    // validly prepared (a quorum of PREPARE votes) at some prior view, refuse to
     // accept a *different* block for the same sequence. We can't yet
     // automatically carry the old block forward, but we must not let a new
     // leader silently override an already-prepared one. See #doViewChange.
@@ -345,7 +345,7 @@ export class PBFTConsensus {
    * VIEW-CHANGE messages is observed — see #handleViewChange), but the
    * message type is part of the wire protocol and a malicious or buggy peer
    * could send one unsolicited. We must not act on it unless it's actually
-   * backed by a real quorum (2f+1) of validly-signed, distinct-sender
+   * backed by a real quorum (`n - f`) of validly-signed, distinct-sender
    * VIEW-CHANGE messages agreeing on the claimed view — otherwise a single
    * validator could force every other node to jump views at will.
    */

--- a/packages/consensus/src/types.ts
+++ b/packages/consensus/src/types.ts
@@ -42,11 +42,16 @@ export interface PrePrepareMessage {
   digest: Uint8Array
   /** The proposing leader's public key. */
   from: Uint8Array
-  /** Signature over `voteDigest('pre-prepare', view, sequence, digest)`, by
-   *  `from`. Verified before the proposal is accepted — without it, a proposal
-   *  is authenticated only by whatever `from` the transport supplies, so any
-   *  transport that does not itself authenticate peers (a relay, a gossip hub,
-   *  a signalling server forwarding a self-declared id) could inject blocks. */
+  /** Signature by `from` over `voteDigest({ phase: 'pre-prepare', chainId,
+   *  epoch, view, sequence, digest })`. Verified before the proposal is
+   *  accepted — without it, a proposal is authenticated only by whatever
+   *  `from` the transport supplies, so any transport that does not itself
+   *  authenticate peers (a relay, a gossip hub, a signalling server
+   *  forwarding a self-declared id) could inject blocks.
+   *
+   *  `chainId` and `epoch` are not on the wire: each node supplies its own,
+   *  so a vote from a different chain or a different validator set fails to
+   *  verify rather than arriving with its scope self-declared. */
   signature: Uint8Array
 }
 
@@ -56,10 +61,12 @@ export interface PrepareMessage {
   sequence: bigint
   digest: Uint8Array
   from: Uint8Array
-  /** Signature over `voteDigest('prepare', view, sequence, digest)`, by `from`.
-   *  Verified before counting toward quorum. The phase tag, view and sequence
-   *  are inside the signed bytes so the vote cannot be replayed as a COMMIT,
-   *  or into another view or sequence. */
+  /** Signature by `from` over `voteDigest({ phase: 'prepare', chainId, epoch,
+   *  view, sequence, digest })`. Verified before counting toward quorum. The
+   *  phase tag, chain, validator-set epoch, view and sequence are all inside
+   *  the signed bytes, so the vote cannot be replayed as a COMMIT, onto
+   *  another chain, across a membership change, or into another view or
+   *  sequence. */
   signature: Uint8Array
 }
 
@@ -69,7 +76,8 @@ export interface CommitMessage {
   sequence: bigint
   digest: Uint8Array
   from: Uint8Array
-  /** Signature over `voteDigest('commit', view, sequence, digest)`, by `from`. */
+  /** Signature by `from` over `voteDigest({ phase: 'commit', chainId, epoch,
+   *  view, sequence, digest })`. */
   signature: Uint8Array
 }
 
@@ -78,10 +86,11 @@ export interface ViewChangeMessage {
   newView: bigint
   sequence: bigint
   from: Uint8Array
-  /** Signature over `voteDigest('view-change', newView, sequence,
-   *  NO_BLOCK_DIGEST)`, by `from`. Verified before counting toward a NEW-VIEW
-   *  quorum. Replay of an old VIEW-CHANGE is stopped by the monotonic view
-   *  check in the handler, not by the signature. */
+  /** Signature by `from` over `voteDigest({ phase: 'view-change', chainId,
+   *  epoch, view: newView, sequence, digest: NO_BLOCK_DIGEST })`. Verified
+   *  before counting toward a NEW-VIEW quorum. Replay of an old VIEW-CHANGE
+   *  *within* one chain and epoch is stopped by the monotonic view check in
+   *  the handler, not by the signature. */
   signature: Uint8Array
 }
 

--- a/packages/consensus/src/validator-set.ts
+++ b/packages/consensus/src/validator-set.ts
@@ -2,11 +2,19 @@
  * Validator set management with deterministic leader rotation.
  */
 
-import { toHex } from '@johnhenry/raijin-core'
+import { toHex, hash, encodeBytes } from '@johnhenry/raijin-core'
+
+/**
+ * Domain tag for the epoch digest, so a validator-set identifier cannot
+ * collide with any other hash in the protocol.
+ */
+const EPOCH_TAG = new TextEncoder().encode('raijin/pbft/v2/validator-set')
 
 export class ValidatorSet {
   #validators: Uint8Array[]
   #indexMap: Map<string, number>
+  /** Memoized `epoch()`; dropped whenever the membership changes. */
+  #epoch: Uint8Array | null = null
 
   constructor(validators: Uint8Array[] = []) {
     this.#validators = [...validators]
@@ -19,6 +27,7 @@ export class ValidatorSet {
     for (let i = 0; i < this.#validators.length; i++) {
       this.#indexMap.set(toHex(this.#validators[i]), i)
     }
+    this.#epoch = null
   }
 
   /** Add a validator. Returns false if already present. */
@@ -27,6 +36,7 @@ export class ValidatorSet {
     if (this.#indexMap.has(key)) return false
     this.#indexMap.set(key, this.#validators.length)
     this.#validators.push(pubkey)
+    this.#epoch = null
     return true
   }
 
@@ -38,6 +48,48 @@ export class ValidatorSet {
     this.#validators.splice(idx, 1)
     this.#rebuildIndex()
     return true
+  }
+
+  /**
+   * The epoch: a 32-byte identifier for *this exact set, in this exact
+   * order*. Every vote signature covers it (see `voteDigest`).
+   *
+   * It is a digest of the membership rather than a counter, and that is the
+   * point. A counter only says how many times a set changed, so two nodes
+   * that applied *different* changes still agree on "epoch 2" and go on
+   * counting each other's votes. A digest makes the epoch the identity of the
+   * set: disagree about who is in it, and you disagree about the epoch, and
+   * votes stop crossing between the two. In particular a validator that has
+   * been removed cannot have its old, still-valid signatures counted toward
+   * the quorum of the set that removed it.
+   *
+   * Order is included because order is consensus-relevant here —
+   * `leaderForView` picks by index, so the same members in a different order
+   * elect different leaders and are genuinely a different set.
+   *
+   * Memoized; recomputed after `add()` or `remove()`.
+   */
+  async epoch(): Promise<Uint8Array> {
+    if (this.#epoch) return this.#epoch
+
+    // Length-prefix each key so that concatenation cannot lose the boundary
+    // between two of them — without it, sets with differently-sized keys
+    // could flatten to the same bytes.
+    const parts: Uint8Array[] = [EPOCH_TAG]
+    for (const validator of this.#validators) {
+      parts.push(encodeBytes(validator))
+    }
+
+    const total = parts.reduce((sum, p) => sum + p.length, 0)
+    const payload = new Uint8Array(total)
+    let pos = 0
+    for (const part of parts) {
+      payload.set(part, pos)
+      pos += part.length
+    }
+
+    this.#epoch = await hash(payload)
+    return this.#epoch
   }
 
   /** Check if a public key is in the validator set. */

--- a/packages/consensus/src/vote.ts
+++ b/packages/consensus/src/vote.ts
@@ -2,69 +2,149 @@
  * Domain-separated payloads for PBFT vote signatures.
  *
  * Every signature a validator produces must be usable in exactly one place:
- * one phase, one view, one sequence, one block. Signing a bare digest is not
- * enough, and the failure is not subtle — if PREPARE and COMMIT both sign
- * `digest`, then a PREPARE, which is broadcast to every peer, *is* a valid
- * COMMIT from the same validator, and the commit phase stops proving anything.
- * Likewise, a signature that does not cover `view`/`sequence` can be lifted
- * into a later round unchanged.
+ * one chain, one validator set, one phase, one view, one sequence, one block.
+ * Signing a bare digest is not enough, and the failure is not subtle — if
+ * PREPARE and COMMIT both sign `digest`, then a PREPARE, which is broadcast
+ * to every peer, *is* a valid COMMIT from the same validator, and the commit
+ * phase stops proving anything. Likewise, a signature that does not cover
+ * `view`/`sequence` can be lifted into a later round unchanged.
+ *
+ * Two more scopes, for the same reason:
+ *
+ * - **`chainId`.** Without it, a vote is only ever a vote about "some block
+ *   at view v, sequence s". Two deployments that share a validator — a
+ *   testnet and a mainnet, a fork and its parent, two tenants of the same
+ *   operator — can replay each other's votes verbatim, and each will count
+ *   them toward its own quorum. This is the same hole `chainId` closes for
+ *   transactions in the SDK, and it is closed the same way: no default. A
+ *   default id is one every deployment that never chose shares.
+ *
+ * - **`epoch`.** A vote authorizes a decision by a *specific validator set*.
+ *   Without the set in the signed bytes, votes survive membership changes: a
+ *   validator that has been removed still has valid signatures lying on the
+ *   wire, and those signatures keep counting toward the quorum of the set
+ *   that removed them. Binding the epoch means a vote cast under one set is
+ *   simply not a vote under any other.
  */
 
-import { hash } from '@johnhenry/raijin-core'
+import { hash, encodeBigInt, encodeBytes } from '@johnhenry/raijin-core'
 
 /** Which vote a signature authorizes. Part of the signed bytes. */
 export type VotePhase = 'pre-prepare' | 'prepare' | 'commit' | 'view-change'
 
-/** Versioned domain tag per phase. Changing a tag invalidates old signatures. */
+/**
+ * Versioned domain tag per phase. Changing a tag invalidates old signatures.
+ *
+ * `v2` adds `chainId` and the validator-set `epoch` to the payload and moves
+ * the integers to LEB128. The version is in the tag precisely so that a v1
+ * signature cannot be replayed against a v2 payload by an implementation that
+ * happens to reconstruct the rest of the fields.
+ */
 const DOMAIN_TAGS: Record<VotePhase, string> = {
-  'pre-prepare': 'raijin/pbft/v1/pre-prepare',
-  'prepare': 'raijin/pbft/v1/prepare',
-  'commit': 'raijin/pbft/v1/commit',
-  'view-change': 'raijin/pbft/v1/view-change',
+  'pre-prepare': 'raijin/pbft/v2/pre-prepare',
+  'prepare': 'raijin/pbft/v2/prepare',
+  'commit': 'raijin/pbft/v2/commit',
+  'view-change': 'raijin/pbft/v2/view-change',
 }
 
 const encoder = new TextEncoder()
 
-/** Big-endian 8-byte encoding of a bigint, matching the block-header codec. */
-function bigintToBytes(value: bigint): Uint8Array {
-  const hex = value.toString(16).padStart(16, '0')
-  const bytes = new Uint8Array(8)
-  for (let i = 0; i < 8; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  }
-  return bytes
-}
-
 /** A digest slot for votes that commit to no block (VIEW-CHANGE). */
 export const NO_BLOCK_DIGEST = new Uint8Array(32)
+
+/** Everything one vote is scoped to. All of it is signed. */
+export interface Vote {
+  /** Which vote this is. */
+  phase: VotePhase
+  /**
+   * Chain identifier — which deployment this vote is about. Required: see
+   * the note on `chainId` at the top of this file.
+   */
+  chainId: bigint
+  /**
+   * Validator-set epoch: an opaque identifier for the exact set (and order)
+   * of validators this vote was cast under. `ValidatorSet#epoch()` produces
+   * it; treat it as opaque bytes here.
+   */
+  epoch: Uint8Array
+  /** The view this vote belongs to. */
+  view: bigint
+  /** The sequence number this vote belongs to. */
+  sequence: bigint
+  /** The block digest being voted on, or `NO_BLOCK_DIGEST` for VIEW-CHANGE. */
+  digest: Uint8Array
+}
 
 /**
  * The bytes a validator signs for one vote.
  *
- * `H(tag || 0x00 || view || sequence || digest)`. The `0x00` separator keeps
- * the variable-length tag from running into the fixed-width fields, so no two
- * distinct (phase, view, sequence, digest) tuples can produce the same input.
+ * `H(tag ‖ 0x00 ‖ chainId ‖ epoch ‖ view ‖ sequence ‖ digest)`, where the
+ * integers are LEB128 and `epoch`/`digest` are length-prefixed. Every field
+ * is therefore self-delimiting, so no two distinct votes can produce the same
+ * input — which is the whole property this function exists to provide. The
+ * `0x00` separator keeps the variable-length tag from running into the first
+ * field; no tag contains a zero byte.
+ *
+ * Takes a single object rather than positional arguments on purpose: four of
+ * the six fields are bigints or byte strings of the same shape, and a
+ * transposed pair would silently produce a valid-looking signature over the
+ * wrong scope.
  *
  * Exported so that a transport, relay or test can construct and check a vote
  * without re-deriving the layout — there is one definition, and this is it.
  */
-export async function voteDigest(
-  phase: VotePhase,
-  view: bigint,
-  sequence: bigint,
-  digest: Uint8Array,
-): Promise<Uint8Array> {
-  const tag = encoder.encode(DOMAIN_TAGS[phase])
-  const viewBytes = bigintToBytes(view)
-  const seqBytes = bigintToBytes(sequence)
+export async function voteDigest(vote: Vote): Promise<Uint8Array> {
+  const tag = DOMAIN_TAGS[vote.phase]
+  if (tag === undefined) {
+    throw new TypeError(`voteDigest: unknown vote phase ${JSON.stringify(vote.phase)}`)
+  }
 
-  const payload = new Uint8Array(tag.length + 1 + viewBytes.length + seqBytes.length + digest.length)
-  let pos = 0
-  payload.set(tag, pos); pos += tag.length
-  payload[pos++] = 0x00
-  payload.set(viewBytes, pos); pos += viewBytes.length
-  payload.set(seqBytes, pos); pos += seqBytes.length
-  payload.set(digest, pos)
+  const chainId = requireIndex(vote.chainId, 'chainId')
+  const view = requireIndex(vote.view, 'view')
+  const sequence = requireIndex(vote.sequence, 'sequence')
+
+  if (!(vote.epoch instanceof Uint8Array)) {
+    throw new TypeError('voteDigest: epoch is required and must be a Uint8Array')
+  }
+  if (!(vote.digest instanceof Uint8Array)) {
+    throw new TypeError('voteDigest: digest is required and must be a Uint8Array')
+  }
+
+  const payload = concat([
+    encoder.encode(tag),
+    new Uint8Array([0x00]),
+    encodeBigInt(chainId),
+    encodeBytes(vote.epoch),
+    encodeBigInt(view),
+    encodeBigInt(sequence),
+    encodeBytes(vote.digest),
+  ])
 
   return hash(payload)
+}
+
+/**
+ * A bigint field that indexes into the protocol. Negative values are not
+ * merely invalid, they collide: LEB128 encodes every negative to the same
+ * empty string, so two different "views" would sign identical bytes.
+ */
+function requireIndex(value: bigint, name: string): bigint {
+  if (typeof value !== 'bigint') {
+    throw new TypeError(`voteDigest: ${name} is required and must be a bigint`)
+  }
+  if (value < 0n) {
+    throw new RangeError(`voteDigest: ${name} must not be negative, got ${value}`)
+  }
+  return value
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0)
+  const out = new Uint8Array(total)
+  let pos = 0
+  for (const part of parts) {
+    out.set(part, pos)
+    pos += part.length
+  }
+  return out
 }

--- a/packages/consensus/test/byzantine.test.ts
+++ b/packages/consensus/test/byzantine.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Byzantine faults — a validator that lies, not one that stops.
+ *
+ * Every other fault test in this repo (and in the test harness) models a
+ * crash: the node goes away and says nothing more. That is the easy half of
+ * the fault model, and it is not the half raijin exists for. A Byzantine
+ * validator keeps talking. It holds a real key, so every message it emits is
+ * correctly signed and correctly formed — authentication is not what stops
+ * it. Quorum intersection and the three-phase commit are what stop it, and
+ * those are what these tests actually exercise.
+ *
+ * The peers here are real `PBFTConsensus` instances. Only the attacker is
+ * synthetic (`ByzantinePeer` — a transport plus a key, see helpers.ts), which
+ * is exactly the shape of the real threat: an honest implementation cannot be
+ * made to equivocate, so the attacker must not be one.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { StateMachine, InMemoryStateStore, toHex, type Block } from '@johnhenry/raijin-core'
+import { PBFTConsensus, ValidatorSet, PBFTPhase } from '../src/index.js'
+import {
+  DeterministicNetwork,
+  MockTimer,
+  ByzantinePeer,
+  mockVerifier,
+  mockSign,
+  makeTestKey,
+} from './helpers.js'
+
+/**
+ * A minimal valid block, made distinguishable by `tag`.
+ *
+ * `tag` lands in `txRoot`, which (a) is part of the header and so changes the
+ * consensus digest, and (b) is never rewritten by execution — unlike
+ * `stateRoot`/`receiptRoot`, which `#onCommitted` overwrites after applying
+ * the block. So `txRoot` is what a test can use to ask "*which* block did
+ * this peer finalize?" after the fact.
+ */
+function makeBlock(number: bigint, proposer: Uint8Array, tag: number): Block {
+  const txRoot = new Uint8Array(32)
+  txRoot.fill(tag)
+  return {
+    header: {
+      number,
+      parentHash: new Uint8Array(32),
+      stateRoot: new Uint8Array(32),
+      txRoot,
+      receiptRoot: new Uint8Array(32),
+      timestamp: 1_700_000_000_000,
+      proposer,
+    },
+    transactions: [],
+    signatures: [],
+  }
+}
+
+/**
+ * The chain these tests vote in. Vote signatures cover it (see `voteDigest`),
+ * so a liar has to name the same chain as the peers it is lying to — being on
+ * the wrong chain is not an attack, it is just an invalid signature.
+ */
+const CHAIN_ID = 1n
+
+/** The scope every `ByzantinePeer` here signs under: same chain, same set. */
+function byzOpts(validators: ValidatorSet) {
+  return { chainId: CHAIN_ID, validators }
+}
+
+/** Which block a finalized header came from — see `makeBlock`. */
+function blockTag(block: Block): number {
+  return block.header.txRoot[0]
+}
+
+describe('Byzantine validators', () => {
+  let network: DeterministicNetwork
+
+  beforeEach(() => {
+    network = new DeterministicNetwork()
+  })
+
+  /**
+   * Drain the network to a standstill.
+   *
+   * PBFT's reactions are fire-and-forget async chains hanging off real
+   * `crypto.subtle` calls (hashing, signing), and some of them — the view
+   * timer's `#requestViewChange` in particular — are started by a timer
+   * firing rather than by a message arriving, so the queue can be empty at
+   * the instant a broadcast is imminent. Draining once is not evidence that
+   * nothing is coming; alternate drains with macrotask yields.
+   */
+  async function settle(passes = 8): Promise<void> {
+    for (let i = 0; i < passes; i++) {
+      await network.drainAll()
+      await new Promise((r) => setTimeout(r, 0))
+    }
+    await network.drainAll()
+  }
+
+  /** A real, honest PBFT peer wired to the shared deterministic network. */
+  function honestPeer(key: Uint8Array, validators: ValidatorSet) {
+    const store = new InMemoryStateStore()
+    const sm = new StateMachine(store, mockVerifier)
+    const timer = new MockTimer()
+    const consensus = new PBFTConsensus({
+      identity: key,
+      chainId: CHAIN_ID,
+      validators,
+      transport: network.createTransport(key),
+      timer,
+      stateMachine: sm,
+      sign: mockSign(key),
+      verify: mockVerifier,
+      blockTime: 100,
+      viewTimeout: 500,
+    })
+    const finalized: Block[] = []
+    consensus.onBlockFinalized((block) => finalized.push(block))
+    consensus.start()
+    return { key, consensus, timer, finalized }
+  }
+
+  describe('an equivocating proposer', () => {
+    /**
+     * The canonical Byzantine leader, and the reason PBFT has three phases
+     * instead of two: it proposes block A to one group of replicas and block
+     * B to another, at the same view and the same sequence, with every
+     * message correctly signed.
+     *
+     * n = 4, f = 1, quorum = 3. The leader is the Byzantine one, so the three
+     * honest replicas are split 1 / 2. Whichever way they split, the group of
+     * one can reach at most 2 PREPAREs (itself plus the liar) and never
+     * prepares at all. Only the group of two can reach quorum, and it does so
+     * on a single block.
+     *
+     * The property under test is NOT "something threw" — nothing throws, and
+     * a Byzantine leader is entitled to be ignored silently. It is that the
+     * honest replicas do not commit two different blocks at one sequence.
+     */
+    it('cannot get two honest replicas to commit different blocks at the same sequence', async () => {
+      const byz = makeTestKey(1) // leader for view 0
+      const k2 = makeTestKey(2)
+      const k3 = makeTestKey(3)
+      const k4 = makeTestKey(4)
+      // n = 4, f = 1, quorum = 3 (asserted in validator-set.test.ts; not
+      // re-asserted here, so that breaking the quorum rule shows up as the
+      // safety failure below rather than as a failed precondition).
+      const validators = new ValidatorSet([byz, k2, k3, k4])
+
+      const p2 = honestPeer(k2, validators)
+      const p3 = honestPeer(k3, validators)
+      const p4 = honestPeer(k4, validators)
+
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), byzOpts(validators))
+
+      // Block A to {k2}; block B to {k3, k4}. Same view, same sequence.
+      const blockA = makeBlock(1n, byz, 0xaa)
+      const blockB = makeBlock(1n, byz, 0xbb)
+      const [digestA, digestB] = await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [
+          { targets: [k2], block: blockA },
+          { targets: [k3, k4], block: blockB },
+        ],
+      })
+      expect(toHex(digestA)).not.toBe(toHex(digestB))
+
+      await network.drainAll()
+
+      // Every honest replica that finalized anything at this sequence
+      // finalized the SAME block. This is the safety property; the count is
+      // secondary.
+      const finalizedTags = new Set(
+        [...p2.finalized, ...p3.finalized, ...p4.finalized].map(blockTag),
+      )
+      expect(finalizedTags.size).toBeLessThanOrEqual(1)
+
+      // And concretely: the isolated replica never even prepared, because it
+      // could only ever see 2 of the 3 PREPAREs block A needs.
+      expect(p2.finalized).toHaveLength(0)
+      expect(p2.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      // The two-replica group did reach quorum, on block B and only block B —
+      // stated so this test cannot pass by nothing happening at all.
+      expect(p3.finalized).toHaveLength(1)
+      expect(p4.finalized).toHaveLength(1)
+      expect(blockTag(p3.finalized[0])).toBe(0xbb)
+      expect(blockTag(p4.finalized[0])).toBe(0xbb)
+
+      for (const p of [p2, p3, p4]) p.consensus.stop()
+    })
+
+    /**
+     * The same attack at n = 3, where the old quorum rule was fatal.
+     *
+     * n = 3 gives f = floor((3-1)/3) = 0, so the old `2f + 1` rule made the
+     * quorum ONE: a replica reached its own PREPARE quorum on its own vote
+     * and finalized alone. An equivocating leader then hands each of the two
+     * honest replicas a different block and both commit it — a fork, from a
+     * single faulty node, with no forged signatures anywhere.
+     *
+     * `n - f` makes the quorum 3 at n = 3: the two honest replicas each see
+     * 2 PREPAREs and neither commits. Liveness is lost (correctly — n = 3
+     * tolerates zero faults) but safety holds.
+     */
+    it('cannot fork a 3-validator set, where the old 2f+1 quorum let one liar split it', async () => {
+      const byz = makeTestKey(1) // leader for view 0
+      const k2 = makeTestKey(2)
+      const k3 = makeTestKey(3)
+      // n = 3 gives f = 0, so 2f+1 would be a quorum of ONE — a replica
+      // finalizing on its own vote. n-f gives 3. (Quorum arithmetic is
+      // asserted in validator-set.test.ts; deliberately not re-asserted here,
+      // so that reverting the rule fails this test on the fork below.)
+      const validators = new ValidatorSet([byz, k2, k3])
+
+      const p2 = honestPeer(k2, validators)
+      const p3 = honestPeer(k3, validators)
+
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), byzOpts(validators))
+      await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [
+          { targets: [k2], block: makeBlock(1n, byz, 0xaa) },
+          { targets: [k3], block: makeBlock(1n, byz, 0xbb) },
+        ],
+      })
+      await network.drainAll()
+
+      // The assertion that matters: the two honest replicas did not commit
+      // conflicting blocks.
+      const tags = new Set([...p2.finalized, ...p3.finalized].map(blockTag))
+      expect(tags.size).toBeLessThanOrEqual(1)
+
+      // Concretely, at n = 3 nothing commits at all — one Byzantine node out
+      // of three is over the tolerance, so stalling is the correct outcome.
+      expect(p2.finalized).toHaveLength(0)
+      expect(p3.finalized).toHaveLength(0)
+
+      for (const p of [p2, p3]) p.consensus.stop()
+    })
+  })
+
+  describe('a conflicting re-proposal after a view change', () => {
+    /**
+     * The scenario an incomplete prepared-certificate carry-over leaves open,
+     * and the one `PBFTConsensus#preparedCert` exists to close.
+     *
+     * A block reaches a PREPARE quorum in view 0 among the replicas that can
+     * still hear each other, but never reaches a COMMIT quorum. The replica
+     * on the far side of the split never learns it happened. That replica is
+     * the leader of view 1, and it proposes a DIFFERENT block at the same
+     * sequence — not maliciously, just ignorantly, which is why this cannot
+     * be dismissed as "don't run a Byzantine leader".
+     *
+     * A replica that already prepared X at sequence 1 must refuse Y at
+     * sequence 1, whatever view Y arrives in. And it must still accept X
+     * again, or the guard is just an outage.
+     */
+    it('cannot replace a block already prepared at a sequence, but still accepts that same block', async () => {
+      const byz = makeTestKey(1) // leader for view 0
+      const k2 = makeTestKey(2) // leader for view 1
+      const k3 = makeTestKey(3)
+      const k4 = makeTestKey(4)
+      const validators = new ValidatorSet([byz, k2, k3, k4])
+
+      const p2 = honestPeer(k2, validators)
+      const p3 = honestPeer(k3, validators)
+      const p4 = honestPeer(k4, validators)
+
+      // ── View 0: block X prepares on the {k3, k4} side only ──
+      //
+      // The view-0 leader tells k3 and k4 about block X and says nothing to
+      // k2 — from k2's side that is indistinguishable from a partition. The
+      // leader sends its PREPARE but deliberately NO COMMIT, so X reaches a
+      // PREPARE quorum ({k3, k4, leader} = 3) and stops one vote short of a
+      // COMMIT quorum. That is the dangerous state: prepared, not committed.
+      const blockX = makeBlock(1n, byz, 0x11)
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), byzOpts(validators))
+      await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [{ targets: [k3, k4], block: blockX }],
+        commit: false,
+      })
+      await settle()
+
+      expect(p3.consensus.phase).toBe(PBFTPhase.Prepared)
+      expect(p4.consensus.phase).toBe(PBFTPhase.Prepared)
+      expect(p3.finalized).toHaveLength(0)
+      expect(p4.finalized).toHaveLength(0)
+      // k2 saw votes for a sequence it has never heard a proposal for, and
+      // correctly ignored them — it is about to lead view 1 knowing nothing.
+      expect(p2.consensus.phase).toBe(PBFTPhase.Idle)
+
+      // ── View change to view 1 ──
+      for (const p of [p2, p3, p4]) p.timer.advance(600)
+      await settle()
+
+      for (const p of [p2, p3, p4]) expect(p.consensus.currentView).toBe(1n)
+      expect(p2.consensus.isLeader).toBe(true)
+
+      // ── View 1: the new leader proposes a conflicting block at sequence 1 ──
+      const blockY = makeBlock(1n, k2, 0x22)
+      await p2.consensus.propose(blockY)
+      await settle()
+
+      // k3 and k4 hold a prepared certificate for X at sequence 1 and must
+      // refuse Y. Nothing anywhere finalizes Y.
+      expect(p3.consensus.phase).toBe(PBFTPhase.Idle)
+      expect(p4.consensus.phase).toBe(PBFTPhase.Idle)
+      const allFinalized = [...p2.finalized, ...p3.finalized, ...p4.finalized]
+      expect(allFinalized.map(blockTag)).not.toContain(0x22)
+      expect(allFinalized).toHaveLength(0)
+
+      // ── And the guard is not simply "refuse everything" ──
+      // A new leader that HAD learned about X (what full prepared-certificate
+      // carry-over would give it) re-proposes X itself, and that is accepted.
+      const asNewLeader = new ByzantinePeer(k2, network.createTransport(k2), { ...byzOpts(validators), listen: false })
+      await asNewLeader.prePrepare([k3, k4], 1n, 1n, blockX)
+      await settle()
+
+      expect(p3.consensus.phase).toBe(PBFTPhase.PrePrepared)
+      expect(p4.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      for (const p of [p2, p3, p4]) p.consensus.stop()
+    })
+  })
+
+  describe('an equivocating voter', () => {
+    /**
+     * A validator that votes for a block nobody proposed, at the same view
+     * and sequence as the one that was.
+     *
+     * Vote sets are keyed by digest, so a vote for a phantom block lands in
+     * its own bucket and cannot carry the real block over the line. That
+     * sounds obvious; it is the difference between counting "who has voted"
+     * and counting "who has voted *for this block*", and only the second one
+     * is a quorum.
+     *
+     * The round here is deliberately balanced on exactly this: the real block
+     * has two of the three votes it needs, and the liar holds the third.
+     */
+    it('cannot advance a block by spending its vote on a different one', async () => {
+      const k1 = makeTestKey(1) // honest leader
+      const k2 = makeTestKey(2) // honest
+      const k3 = makeTestKey(3) // honest, silent for now
+      const byz = makeTestKey(4)
+      const validators = new ValidatorSet([k1, k2, k3, byz])
+
+      const p1 = honestPeer(k1, validators)
+
+      const real = makeBlock(1n, k1, 0x33)
+      await p1.consensus.propose(real)
+      await settle()
+
+      const realDigest = await ByzantinePeer.digestOf(real)
+      const phantomDigest = await ByzantinePeer.digestOf(makeBlock(1n, k1, 0x44))
+
+      // One honest vote for the real block: {leader, k2} = 2 of 3.
+      const honest2 = new ByzantinePeer(k2, network.createTransport(k2), { ...byzOpts(validators), listen: false })
+      await honest2.prepare([k1], 0n, 1n, realDigest)
+
+      // The liar holds the third vote and spends it on a block nobody
+      // proposed — correctly signed, right view, right sequence, wrong block.
+      // It commits to the phantom too, for good measure.
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), { ...byzOpts(validators), listen: false })
+      await liar.prepare([k1], 0n, 1n, phantomDigest)
+      await liar.commit([k1], 0n, 1n, phantomDigest)
+      await settle()
+
+      // The real block is still one vote short, and nothing finalized.
+      expect(p1.finalized).toHaveLength(0)
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      // One genuine vote for the real block is all that was missing — so the
+      // round was healthy and the liar's vote was the only thing withheld.
+      const honest3 = new ByzantinePeer(k3, network.createTransport(k3), { ...byzOpts(validators), listen: false })
+      await honest3.prepare([k1], 0n, 1n, realDigest)
+      await settle()
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+
+      p1.consensus.stop()
+    })
+
+    /**
+     * The same validator sending the same valid vote over and over.
+     *
+     * Quorum counts distinct validators, not messages. A repeated vote is
+     * indistinguishable from a re-broadcast on a lossy link, so this must be
+     * handled by counting, not by rejecting — and it is the cheapest possible
+     * attack: no forgery, no timing, just say it again.
+     */
+    it('cannot reach quorum by repeating one valid vote', async () => {
+      const k1 = makeTestKey(1) // honest leader
+      const k2 = makeTestKey(2)
+      const k3 = makeTestKey(3)
+      const byz = makeTestKey(4)
+      const validators = new ValidatorSet([k1, k2, k3, byz])
+
+      const p1 = honestPeer(k1, validators)
+
+      const block = makeBlock(1n, k1, 0x55)
+      await p1.consensus.propose(block)
+      await settle()
+      const digest = await ByzantinePeer.digestOf(block)
+
+      // k2 and k3 are silent. The liar repeats its one vote five times —
+      // enough to clear a quorum of 3 if messages were counted.
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), { ...byzOpts(validators), listen: false })
+      for (let i = 0; i < 5; i++) {
+        await liar.prepare([k1], 0n, 1n, digest)
+        await liar.commit([k1], 0n, 1n, digest)
+      }
+      await settle()
+
+      // Two distinct validators have voted (leader + liar); quorum is 3.
+      expect(p1.finalized).toHaveLength(0)
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      p1.consensus.stop()
+    })
+  })
+
+  describe('a vote replayed into another phase', () => {
+    /**
+     * A PREPARE is broadcast to every peer, so every peer holds one. If a
+     * PREPARE and a COMMIT sign the same bytes, then holding a validator's
+     * PREPARE *is* holding its COMMIT, and the commit phase proves nothing —
+     * one silent eavesdropper can finalize a block that no quorum ever
+     * committed.
+     *
+     * Unlike the message-level test in pbft.test.ts, the signatures replayed
+     * here are not hand-built: the Byzantine node harvested them off the wire
+     * from votes real peers actually broadcast. That is how the attack would
+     * happen, and it is why `voteDigest` puts the phase inside the signed
+     * bytes.
+     */
+    it('cannot turn PREPAREs it overheard into the COMMITs a block still needs', async () => {
+      const k1 = makeTestKey(1) // honest leader under test
+      const k2 = makeTestKey(2)
+      const k3 = makeTestKey(3)
+      const byz = makeTestKey(4)
+      const validators = new ValidatorSet([k1, k2, k3, byz])
+
+      const p1 = honestPeer(k1, validators)
+
+      // The eavesdropper: registered on the network, sends nothing of its own,
+      // and relays through a transport that lets it choose the `from` it
+      // announces. That last part is not cheating — the in-memory networks
+      // here bind `from` to the sending transport, which authenticates every
+      // peer for free and is precisely what a real relay, gossip hub or
+      // signalling server does NOT do. `PBFTConsensus` is written for that
+      // world: it treats `from` as a claim and puts the phase, view and
+      // sequence inside the signed bytes so the claim can be settled.
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), {
+        ...byzOpts(validators),
+        spoof: (identity) => network.createTransport(identity),
+      })
+
+      const block = makeBlock(1n, k1, 0x66)
+      await p1.consensus.propose(block)
+      await settle()
+      const digest = await ByzantinePeer.digestOf(block)
+
+      // k2 and k3 prepare and then go quiet before committing (a crash
+      // between phases — the ordinary case, not an attack). Their PREPAREs go
+      // to the leader and, being broadcasts, to the eavesdropper as well.
+      for (const key of [k2, k3]) {
+        const peer = new ByzantinePeer(key, network.createTransport(key), { ...byzOpts(validators), listen: false })
+        await peer.prepare([k1, byz], 0n, 1n, digest)
+      }
+      await settle()
+
+      // The leader now has a PREPARE quorum and has sent its own COMMIT, so
+      // the block sits one short of finalizing: commits = {k1}, needs 3.
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+      expect(p1.finalized).toHaveLength(0)
+
+      // The eavesdropper really did capture two PREPAREs off the wire.
+      const captured = liar.overheardPrepares().filter((m) => toHex(m.from) !== toHex(k1))
+      expect(captured).toHaveLength(2)
+
+      // Replay them at the leader as COMMITs from their original signers,
+      // signatures untouched. Under a bare-digest signing scheme these are
+      // valid COMMITs from k2 and k3 and the block finalizes.
+      for (const prepare of captured) {
+        liar.replayAs([k1], prepare, { type: 'commit' })
+      }
+      await settle()
+
+      expect(p1.finalized).toHaveLength(0)
+      expect(p1.consensus.phase).toBe(PBFTPhase.Prepared)
+
+      p1.consensus.stop()
+    })
+  })
+})

--- a/packages/consensus/test/helpers.ts
+++ b/packages/consensus/test/helpers.ts
@@ -2,8 +2,18 @@
  * Test helpers: mock transport, timer, and multi-peer simulation.
  */
 
-import type { NetworkTransport, ConsensusMessage, ConsensusTimer, TimerHandle } from '../src/types.js'
-import type { SignatureVerifier } from '@johnhenry/raijin-core'
+import type {
+  NetworkTransport,
+  ConsensusMessage,
+  ConsensusTimer,
+  TimerHandle,
+  PrepareMessage,
+  CommitMessage,
+} from '../src/types.js'
+import type { SignatureVerifier, Block } from '@johnhenry/raijin-core'
+import { hash, encodeBlockHeader } from '@johnhenry/raijin-core'
+import { voteDigest, NO_BLOCK_DIGEST, type VotePhase } from '../src/vote.js'
+import { ValidatorSet } from '../src/validator-set.js'
 
 /** In-memory transport that connects multiple peers. Tracks pending async work. */
 export class MockNetwork {
@@ -232,5 +242,264 @@ export class DeterministicNetwork {
   /** Disconnect a peer (simulates crash). */
   disconnect(peerId: Uint8Array): void {
     this.#peers.delete(toHex(peerId))
+  }
+}
+
+// ── Byzantine peers ───────────────────────────────────────────────────
+
+/**
+ * A validator that lies.
+ *
+ * Crash faults are the easy half of the fault model and the only half the
+ * rest of this harness models: a crashed node *stops*. A Byzantine node
+ * keeps sending — it just sends things a correct implementation never
+ * would. It holds a real key, so every message it emits carries a
+ * genuinely valid signature; authentication is not the thing that stops
+ * it. What stops it is quorum intersection and the three-phase commit,
+ * and that is what these peers exist to test.
+ *
+ * `ByzantinePeer` is deliberately *not* a `PBFTConsensus`. It has no
+ * phase, no state machine and no notion of correctness — it is a raw
+ * transport plus a signing key plus the ability to address individual
+ * peers. Anything the wire format permits, it can say.
+ *
+ * The primitives below cover the attacks worth testing:
+ *  - `prePrepare`/`prepare`/`commit`/`viewChange` — correctly-signed votes
+ *    sent to a *chosen subset* of peers rather than broadcast, which is
+ *    all equivocation actually is.
+ *  - `equivocate` — the canonical Byzantine leader: two different blocks
+ *    proposed at the same (view, sequence) to two disjoint groups.
+ *  - `replayAs` — take a vote it overheard and re-emit it under a
+ *    different phase, view or sequence, keeping the original signature.
+ *  - `received` — everything it overheard, so a test can replay real
+ *    traffic rather than hand-built messages.
+ */
+export class ByzantinePeer {
+  readonly publicKey: Uint8Array
+  /** Every message this peer overheard, in delivery order. */
+  readonly received: Array<{ from: Uint8Array; msg: ConsensusMessage }> = []
+
+  #transport: NetworkTransport
+  #sign: (message: Uint8Array) => Promise<Uint8Array>
+  #spoof: ((identity: Uint8Array) => NetworkTransport) | null
+  #chainId: bigint
+  #validators: ValidatorSet
+
+  /**
+   * @param chainId     The deployment this peer is voting in. Required for
+   *                    the same reason `PBFTConsensus` requires it: a vote
+   *                    that does not name its chain is replayable into every
+   *                    other chain that shares a validator.
+   * @param validators  The validator set this peer is voting under; its
+   *                    `epoch()` goes into every signed payload. A liar that
+   *                    signed under a different set would simply produce
+   *                    invalid signatures, which tests nothing.
+   * @param listen      Register a message handler so the peer receives
+   *                    broadcasts. Required for replay attacks (it has to
+   *                    hear a vote before it can re-emit one) and for the
+   *                    peer to be a broadcast target at all.
+   * @param spoof       A factory for a transport that reports an arbitrary
+   *                    sender id — pass `(id) => network.createTransport(id)`.
+   *
+   *                    This models a transport that does not authenticate its
+   *                    peers: a relay, a gossip hub, a signalling server
+   *                    forwarding a self-declared id. `PBFTConsensus` is
+   *                    written for exactly that world — it takes the `from`
+   *                    the transport hands it as a *claim* and makes every
+   *                    message carry a signature over `voteDigest(...)` to
+   *                    settle it. Without a spoofing transport a test cannot
+   *                    reach those checks at all, because the in-memory
+   *                    networks here bind `from` to the transport that sent
+   *                    the message and so authenticate every peer for free.
+   */
+  constructor(
+    publicKey: Uint8Array,
+    transport: NetworkTransport,
+    opts: {
+      chainId: bigint
+      validators: ValidatorSet
+      listen?: boolean
+      spoof?: (identity: Uint8Array) => NetworkTransport
+    },
+  ) {
+    this.publicKey = publicKey
+    this.#transport = transport
+    this.#sign = mockSign(publicKey)
+    this.#spoof = opts.spoof ?? null
+    this.#chainId = opts.chainId
+    this.#validators = opts.validators
+    if (opts.listen ?? true) {
+      this.#transport.onMessage((from, msg) => {
+        this.received.push({ from, msg })
+      })
+    }
+  }
+
+  /** The digest PBFT agrees on for a block: `H(encodeBlockHeader(header))`. */
+  static async digestOf(block: Block): Promise<Uint8Array> {
+    return hash(encodeBlockHeader(block.header))
+  }
+
+  /** Sign one vote exactly as an honest validator would. */
+  async signVote(
+    phase: VotePhase,
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+  ): Promise<Uint8Array> {
+    return this.#sign(
+      await voteDigest({
+        phase,
+        chainId: this.#chainId,
+        epoch: await this.#validators.epoch(),
+        view,
+        sequence,
+        digest,
+      }),
+    )
+  }
+
+  /** Send a fully-formed message to exactly one peer. */
+  sendTo(to: Uint8Array, msg: ConsensusMessage): void {
+    this.#transport.send(to, msg)
+  }
+
+  /** Send a fully-formed message to a chosen subset of peers. */
+  sendToAll(targets: Uint8Array[], msg: ConsensusMessage): void {
+    for (const to of targets) this.#transport.send(to, msg)
+  }
+
+  /** A validly-signed PRE-PREPARE for `block`, sent only to `targets`. */
+  async prePrepare(
+    targets: Uint8Array[],
+    view: bigint,
+    sequence: bigint,
+    block: Block,
+  ): Promise<Uint8Array> {
+    const digest = await ByzantinePeer.digestOf(block)
+    this.sendToAll(targets, {
+      type: 'pre-prepare',
+      view,
+      sequence,
+      block,
+      digest,
+      from: this.publicKey,
+      signature: await this.signVote('pre-prepare', view, sequence, digest),
+    })
+    return digest
+  }
+
+  /** A validly-signed PREPARE, sent only to `targets`. */
+  async prepare(
+    targets: Uint8Array[],
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+  ): Promise<void> {
+    this.sendToAll(targets, {
+      type: 'prepare',
+      view,
+      sequence,
+      digest,
+      from: this.publicKey,
+      signature: await this.signVote('prepare', view, sequence, digest),
+    })
+  }
+
+  /** A validly-signed COMMIT, sent only to `targets`. */
+  async commit(
+    targets: Uint8Array[],
+    view: bigint,
+    sequence: bigint,
+    digest: Uint8Array,
+  ): Promise<void> {
+    this.sendToAll(targets, {
+      type: 'commit',
+      view,
+      sequence,
+      digest,
+      from: this.publicKey,
+      signature: await this.signVote('commit', view, sequence, digest),
+    })
+  }
+
+  /** A validly-signed VIEW-CHANGE, sent only to `targets`. */
+  async viewChange(
+    targets: Uint8Array[],
+    newView: bigint,
+    sequence: bigint,
+  ): Promise<void> {
+    this.sendToAll(targets, {
+      type: 'view-change',
+      newView,
+      sequence,
+      from: this.publicKey,
+      signature: await this.signVote('view-change', newView, sequence, NO_BLOCK_DIGEST),
+    })
+  }
+
+  /**
+   * The canonical Byzantine leader: propose two *different* blocks at the
+   * same view and sequence to two disjoint groups, and back each with the
+   * leader's own PREPARE (and optionally COMMIT) so each group sees a
+   * self-consistent round.
+   *
+   * Every message is correctly signed. Nothing here is malformed; the lie
+   * is entirely in who is told what.
+   */
+  async equivocate(opts: {
+    view: bigint
+    sequence: bigint
+    groups: Array<{ targets: Uint8Array[]; block: Block }>
+    /** Also send the leader's COMMIT to each group. Default: true. */
+    commit?: boolean
+  }): Promise<Uint8Array[]> {
+    const digests: Uint8Array[] = []
+    for (const group of opts.groups) {
+      const digest = await this.prePrepare(group.targets, opts.view, opts.sequence, group.block)
+      await this.prepare(group.targets, opts.view, opts.sequence, digest)
+      if (opts.commit ?? true) {
+        await this.commit(group.targets, opts.view, opts.sequence, digest)
+      }
+      digests.push(digest)
+    }
+    return digests
+  }
+
+  /**
+   * Re-emit a vote this peer overheard, keeping the ORIGINAL sender and
+   * the ORIGINAL signature, but changing the phase (and optionally the view
+   * or sequence).
+   *
+   * This is the attack the domain-separated `voteDigest` exists to stop: a
+   * PREPARE is broadcast to everyone, so if PREPARE and COMMIT sign the
+   * same bytes, holding someone's PREPARE means holding their COMMIT.
+   */
+  replayAs(
+    targets: Uint8Array[],
+    original: PrepareMessage | CommitMessage,
+    as: { type: 'prepare' | 'commit'; view?: bigint; sequence?: bigint },
+  ): void {
+    const msg = {
+      type: as.type,
+      view: as.view ?? original.view,
+      sequence: as.sequence ?? original.sequence,
+      digest: original.digest,
+      from: original.from,
+      signature: original.signature,
+    } as ConsensusMessage
+    // Send it under the ORIGINAL signer's id if a spoofing transport was
+    // supplied — a replay that announces itself as coming from the attacker
+    // is not a replay, it is a signature the receiver will check against the
+    // wrong key. See the `spoof` option.
+    const via = this.#spoof ? this.#spoof(original.from) : this.#transport
+    for (const to of targets) via.send(to, msg)
+  }
+
+  /** Every PREPARE this peer overheard. */
+  overheardPrepares(): PrepareMessage[] {
+    return this.received
+      .map((r) => r.msg)
+      .filter((m): m is PrepareMessage => m.type === 'prepare')
   }
 }

--- a/packages/consensus/test/pbft.test.ts
+++ b/packages/consensus/test/pbft.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { StateMachine, InMemoryStateStore, hash, type Block } from '@johnhenry/raijin-core'
+import { StateMachine, InMemoryStateStore, hash, encodeBlockHeader, type Block } from '@johnhenry/raijin-core'
 import { PBFTConsensus, ValidatorSet, PBFTPhase, voteDigest, NO_BLOCK_DIGEST } from '../src/index.js'
 import type { NewViewMessage, PrePrepareMessage, ViewChangeMessage } from '../src/types.js'
 import { MockNetwork, DeterministicNetwork, MockTimer, mockVerifier, mockSign, makeTestKey } from './helpers.js'
@@ -22,35 +22,17 @@ function makeBlock(number: bigint, proposer: Uint8Array): Block {
   }
 }
 
-/** Mirrors PBFTConsensus#serializeBlockHeader + hash — used to construct
- *  messages with a digest that will pass the real digest check. */
-function bigintToBytes(value: bigint): Uint8Array {
-  const hex = value.toString(16).padStart(16, '0')
-  const bytes = new Uint8Array(8)
-  for (let i = 0; i < 8; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  }
-  return bytes
-}
-
+/**
+ * The digest PBFT agrees on: `H(encodeBlockHeader(header))`.
+ *
+ * This used to be a hand-copied reimplementation of the header layout, which
+ * is the one thing a test of a commitment must not be — it kept passing while
+ * silently pinning a *second* definition of the canonical bytes. It calls the
+ * shipped encoder now, so a change to the header format shows up here as
+ * changed digests rather than as agreement with an encoder nobody runs.
+ */
 async function computeDigest(block: Block): Promise<Uint8Array> {
-  const parts: Uint8Array[] = [
-    bigintToBytes(block.header.number),
-    block.header.parentHash,
-    block.header.stateRoot,
-    block.header.txRoot,
-    block.header.receiptRoot,
-    bigintToBytes(BigInt(block.header.timestamp)),
-    block.header.proposer,
-  ]
-  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-  const result = new Uint8Array(totalLen)
-  let pos = 0
-  for (const part of parts) {
-    result.set(part, pos)
-    pos += part.length
-  }
-  return hash(result)
+  return hash(encodeBlockHeader(block.header))
 }
 
 /** Sign one vote the way PBFTConsensus does: over the domain-separated

--- a/packages/consensus/test/pbft.test.ts
+++ b/packages/consensus/test/pbft.test.ts
@@ -35,6 +35,16 @@ async function computeDigest(block: Block): Promise<Uint8Array> {
   return hash(encodeBlockHeader(block.header))
 }
 
+/** The chain these tests run on. Consensus has no default — see PBFTConfig. */
+const TEST_CHAIN_ID = 1n
+
+/**
+ * The validator set every peer in this file is built from. `signVote` needs
+ * its epoch to forge a vote that the peers will accept, the same way it needs
+ * their chain id.
+ */
+let currentValidators: ValidatorSet
+
 /** Sign one vote the way PBFTConsensus does: over the domain-separated
  *  payload from `voteDigest`, not over the bare block digest. */
 async function signVote(
@@ -43,8 +53,16 @@ async function signVote(
   view: bigint,
   sequence: bigint,
   digest: Uint8Array,
+  overrides: { chainId?: bigint; epoch?: Uint8Array } = {},
 ): Promise<Uint8Array> {
-  return mockSign(key)(await voteDigest(phase, view, sequence, digest))
+  return mockSign(key)(await voteDigest({
+    phase,
+    chainId: overrides.chainId ?? TEST_CHAIN_ID,
+    epoch: overrides.epoch ?? await currentValidators.epoch(),
+    view,
+    sequence,
+    digest,
+  }))
 }
 
 /** A validly-signed VIEW-CHANGE from `key`. */
@@ -93,6 +111,7 @@ describe('PBFTConsensus', () => {
   beforeEach(() => {
     network = new DeterministicNetwork()
     validators = new ValidatorSet([key1, key2, key3, key4])
+    currentValidators = validators
   })
 
   function createPeer(key: Uint8Array): { consensus: PBFTConsensus; timer: MockTimer } {
@@ -103,6 +122,7 @@ describe('PBFTConsensus', () => {
 
     const consensus = new PBFTConsensus({
       identity: key,
+      chainId: TEST_CHAIN_ID,
       validators,
       transport,
       timer,
@@ -574,6 +594,97 @@ describe('PBFTConsensus', () => {
   // A PREPARE is broadcast to every peer. If it signs the same bytes a COMMIT
   // signs, then every peer holds a valid COMMIT from every prepared validator,
   // and the commit phase proves nothing. See issue #17.
+  describe('vote signatures are bound to their chain and validator set', () => {
+    // A vote that carries neither is only ever "some block at view v,
+    // sequence s" — it counts on any chain that happens to share a validator,
+    // and it keeps counting after that validator has been removed from the
+    // set. See issue #25.
+    it('does not count a PREPARE signed for a different chain', async () => {
+      const p1 = createPeer(key1) // leader; quorum = 3 of 4
+      p1.consensus.start()
+
+      let finalized = 0
+      p1.consensus.onBlockFinalized(() => finalized++)
+
+      const block = makeBlock(1n, key1)
+      const digest = await computeDigest(block)
+      await p1.consensus.propose(block)
+
+      // Two PREPAREs that are perfectly valid — on chain 2. Everything else
+      // about them matches: real keys, real signatures, right view, right
+      // sequence, right digest.
+      for (const key of [key2, key3]) {
+        network.createTransport(key).send(key1, {
+          type: 'prepare' as const, view: 0n, sequence: 1n, digest, from: key,
+          signature: await signVote(key, 'prepare', 0n, 1n, digest, { chainId: 2n }),
+        })
+      }
+      await network.drainAll()
+
+      // Quorum needs 3 and the leader's own vote is 1: these two must not
+      // have been counted, or the phase would have advanced.
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+      expect(finalized).toBe(0)
+
+      // The same two votes, signed for the right chain, do reach quorum —
+      // so the rejection above was the chain binding and not some unrelated
+      // reason the messages were dropped.
+      for (const key of [key2, key3]) {
+        network.createTransport(key).send(key1, {
+          type: 'prepare' as const, view: 0n, sequence: 1n, digest, from: key,
+          signature: await signVote(key, 'prepare', 0n, 1n, digest),
+        })
+      }
+      await network.drainAll()
+      expect(p1.consensus.phase).not.toBe(PBFTPhase.PrePrepared)
+
+      p1.consensus.stop()
+    })
+
+    it('does not count a PREPARE signed under a different validator set', async () => {
+      const p1 = createPeer(key1)
+      p1.consensus.start()
+
+      const block = makeBlock(1n, key1)
+      const digest = await computeDigest(block)
+      await p1.consensus.propose(block)
+
+      // The epoch of a set that key4 has been removed from. A validator
+      // voting under that set is not voting under this one.
+      const shrunk = new ValidatorSet([key1, key2, key3])
+      const otherEpoch = await shrunk.epoch()
+      expect(otherEpoch).not.toEqual(await validators.epoch())
+
+      for (const key of [key2, key3]) {
+        network.createTransport(key).send(key1, {
+          type: 'prepare' as const, view: 0n, sequence: 1n, digest, from: key,
+          signature: await signVote(key, 'prepare', 0n, 1n, digest, { epoch: otherEpoch }),
+        })
+      }
+      await network.drainAll()
+
+      expect(p1.consensus.phase).toBe(PBFTPhase.PrePrepared)
+
+      p1.consensus.stop()
+    })
+
+    it('refuses to build a consensus engine with no chainId', () => {
+      // Required at the type level; this is the JS caller the types miss.
+      // A default would be an id every deployment that forgot one shares.
+      const config = {
+        identity: key1,
+        validators,
+        transport: network.createTransport(key1),
+        timer: new MockTimer(),
+        stateMachine: new StateMachine(new InMemoryStateStore(), mockVerifier),
+        sign: mockSign(key1),
+        verify: mockVerifier,
+      }
+      expect(() => new PBFTConsensus(config as unknown as ConstructorParameters<typeof PBFTConsensus>[0]))
+        .toThrow(/chainId is required/)
+    })
+  })
+
   describe('vote signatures are bound to their phase, view and sequence', () => {
     it('does not accept a PREPARE signature replayed as that validator COMMIT', async () => {
       const p1 = createPeer(key1) // leader; quorum = 3 of 4

--- a/packages/consensus/test/vote.test.ts
+++ b/packages/consensus/test/vote.test.ts
@@ -1,0 +1,231 @@
+/**
+ * What a vote signature is scoped to.
+ *
+ * These assert relational properties — "these two votes must not sign the
+ * same bytes" — rather than pinning digests to literals. A literal would fix
+ * a second definition of the payload layout alongside the shipped one, which
+ * is the failure mode `pbft.test.ts`'s old hand-copied `computeDigest` had:
+ * it kept passing while agreeing with an encoder nobody ran.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { voteDigest, NO_BLOCK_DIGEST, type VotePhase } from '../src/vote.js'
+import { ValidatorSet } from '../src/validator-set.js'
+import { makeTestKey } from './helpers.js'
+
+const EPOCH_A = new Uint8Array(32).fill(0xa1)
+const EPOCH_B = new Uint8Array(32).fill(0xb2)
+const DIGEST = new Uint8Array(32).fill(0x0d)
+
+/** A baseline vote; each test varies exactly one field of it. */
+function vote(overrides: Partial<Parameters<typeof voteDigest>[0]> = {}) {
+  return {
+    phase: 'prepare' as VotePhase,
+    chainId: 1n,
+    epoch: EPOCH_A,
+    view: 3n,
+    sequence: 7n,
+    digest: DIGEST,
+    ...overrides,
+  }
+}
+
+const hex = (b: Uint8Array) => Array.from(b).map(x => x.toString(16).padStart(2, '0')).join('')
+
+describe('voteDigest', () => {
+  it('is deterministic for the same vote', async () => {
+    expect(hex(await voteDigest(vote()))).toBe(hex(await voteDigest(vote())))
+  })
+
+  // ── chainId ─────────────────────────────────────────────────────────
+  //
+  // Without chainId a vote says only "some block at view v, sequence s".
+  // Two deployments sharing a validator — a testnet and a mainnet, a fork and
+  // its parent — replay each other's votes verbatim and each counts them
+  // toward its own quorum. See issue #25.
+  describe('binds a vote to its chain', () => {
+    it('gives two chains different signed bytes for the same vote', async () => {
+      const onChain1 = await voteDigest(vote({ chainId: 1n }))
+      const onChain2 = await voteDigest(vote({ chainId: 2n }))
+      expect(hex(onChain1)).not.toBe(hex(onChain2))
+    })
+
+    it('separates adjacent chain ids, not just distant ones', async () => {
+      const a = await voteDigest(vote({ chainId: 0n }))
+      const b = await voteDigest(vote({ chainId: 1n }))
+      expect(hex(a)).not.toBe(hex(b))
+    })
+
+    it('requires a chainId — there is no default', async () => {
+      await expect(
+        voteDigest(vote({ chainId: undefined as unknown as bigint })),
+      ).rejects.toThrow(/chainId is required/)
+    })
+
+    it('refuses a negative chainId rather than collapsing it', async () => {
+      // LEB128 encodes every negative bigint to the same empty string, so an
+      // unchecked negative would make distinct scopes sign identical bytes.
+      await expect(voteDigest(vote({ chainId: -1n }))).rejects.toThrow(/must not be negative/)
+    })
+  })
+
+  // ── epoch ───────────────────────────────────────────────────────────
+  //
+  // A vote authorizes a decision by a *specific* validator set. Without the
+  // set in the signed bytes, a validator removed from it still has valid
+  // signatures on the wire that keep counting toward the new set's quorum.
+  describe('binds a vote to its validator-set epoch', () => {
+    it('gives two epochs different signed bytes for the same vote', async () => {
+      const underA = await voteDigest(vote({ epoch: EPOCH_A }))
+      const underB = await voteDigest(vote({ epoch: EPOCH_B }))
+      expect(hex(underA)).not.toBe(hex(underB))
+    })
+
+    it('requires an epoch', async () => {
+      await expect(
+        voteDigest(vote({ epoch: undefined as unknown as Uint8Array })),
+      ).rejects.toThrow(/epoch is required/)
+    })
+
+    it('keeps the epoch boundary distinct from the fields around it', async () => {
+      // `epoch` is variable-length, and the fields after it are LEB128
+      // integers — which are self-delimiting only once you know where they
+      // start. Drop the length prefix and the start becomes ambiguous, so
+      // bytes from the epoch can be read as the view, and bytes from the
+      // sequence as the digest.
+      //
+      // These two votes are genuinely different — different epoch, view,
+      // sequence and digest — and with an unprefixed layout both flatten to
+      //
+      //   01 aa 03 07 01 ff
+      //
+      // i.e. one signature that authorizes both. Constructed by hand rather
+      // than by picking lengths that look suspicious: a witness that does not
+      // actually collide under the broken layout is a test that can never
+      // fail for the reason it names.
+      const a = await voteDigest(vote({
+        chainId: 1n,
+        epoch: new Uint8Array([0xaa, 0x03]),
+        view: 7n,
+        sequence: 1n,
+        digest: new Uint8Array([0xff]),
+      }))
+      const b = await voteDigest(vote({
+        chainId: 1n,
+        epoch: new Uint8Array([0xaa]),
+        view: 3n,
+        sequence: 7n,
+        digest: new Uint8Array([0x01, 0xff]),
+      }))
+      expect(hex(a)).not.toBe(hex(b))
+    })
+  })
+
+  // ── the scopes that were already there ──────────────────────────────
+  //
+  // Regression cover: adding chainId and epoch must not have loosened the
+  // separation that was already load-bearing.
+  describe('still binds phase, view and sequence', () => {
+    it('separates PREPARE from COMMIT', async () => {
+      const prepare = await voteDigest(vote({ phase: 'prepare' }))
+      const commit = await voteDigest(vote({ phase: 'commit' }))
+      expect(hex(prepare)).not.toBe(hex(commit))
+    })
+
+    it('separates every phase from every other', async () => {
+      const phases: VotePhase[] = ['pre-prepare', 'prepare', 'commit', 'view-change']
+      const digests = await Promise.all(phases.map(phase => voteDigest(vote({ phase }))))
+      expect(new Set(digests.map(hex)).size).toBe(phases.length)
+    })
+
+    it('separates views and sequences', async () => {
+      const base = hex(await voteDigest(vote()))
+      expect(hex(await voteDigest(vote({ view: 4n })))).not.toBe(base)
+      expect(hex(await voteDigest(vote({ sequence: 8n })))).not.toBe(base)
+    })
+
+    it('does not confuse a view with a sequence', async () => {
+      // (view 3, seq 7) and (view 7, seq 3) are different rounds.
+      const a = await voteDigest(vote({ view: 3n, sequence: 7n }))
+      const b = await voteDigest(vote({ view: 7n, sequence: 3n }))
+      expect(hex(a)).not.toBe(hex(b))
+    })
+
+    it('rejects an unknown phase', async () => {
+      await expect(
+        voteDigest(vote({ phase: 'commit ' as VotePhase })),
+      ).rejects.toThrow(/unknown vote phase/)
+    })
+  })
+
+  it('accepts NO_BLOCK_DIGEST for a view change', async () => {
+    const d = await voteDigest(vote({ phase: 'view-change', digest: NO_BLOCK_DIGEST }))
+    expect(d.length).toBe(32)
+  })
+})
+
+describe('ValidatorSet.epoch', () => {
+  const [k1, k2, k3] = [makeTestKey(1), makeTestKey(2), makeTestKey(3)]
+
+  it('is stable for an unchanged set', async () => {
+    const set = new ValidatorSet([k1, k2, k3])
+    expect(hex(await set.epoch())).toBe(hex(await set.epoch()))
+  })
+
+  it('agrees between two independently built sets with the same members', async () => {
+    // Two nodes that hold the same set must sign the same bytes, or nothing
+    // reaches quorum.
+    const a = new ValidatorSet([k1, k2, k3])
+    const b = new ValidatorSet([k1, k2, k3])
+    expect(hex(await a.epoch())).toBe(hex(await b.epoch()))
+  })
+
+  it('changes when a validator is removed', async () => {
+    // The property the epoch exists for: the removed validator's old
+    // signatures were made under a different epoch, so they cannot be
+    // counted toward the quorum of the set that removed them.
+    const set = new ValidatorSet([k1, k2, k3])
+    const before = hex(await set.epoch())
+
+    expect(set.remove(k2)).toBe(true)
+    expect(hex(await set.epoch())).not.toBe(before)
+  })
+
+  it('changes when a validator is added', async () => {
+    const set = new ValidatorSet([k1, k2])
+    const before = hex(await set.epoch())
+
+    expect(set.add(k3)).toBe(true)
+    expect(hex(await set.epoch())).not.toBe(before)
+  })
+
+  it('does not change when a no-op add is rejected', async () => {
+    const set = new ValidatorSet([k1, k2])
+    const before = hex(await set.epoch())
+
+    expect(set.add(k1)).toBe(false) // already present
+    expect(hex(await set.epoch())).toBe(before)
+  })
+
+  it('distinguishes two sets that differ only in order', async () => {
+    // `leaderForView` picks by index, so the same members in a different
+    // order elect different leaders — genuinely a different set.
+    const a = new ValidatorSet([k1, k2, k3])
+    const b = new ValidatorSet([k3, k2, k1])
+    expect(hex(await a.epoch())).not.toBe(hex(await b.epoch()))
+  })
+
+  it('distinguishes sets whose keys differ only in where one ends', async () => {
+    // Concatenating keys without a length prefix loses the boundary between
+    // them: [0xaa, 0xbbcc] and [0xaabb, 0xcc] flatten to the same bytes.
+    const a = new ValidatorSet([new Uint8Array([0xaa]), new Uint8Array([0xbb, 0xcc])])
+    const b = new ValidatorSet([new Uint8Array([0xaa, 0xbb]), new Uint8Array([0xcc])])
+    expect(hex(await a.epoch())).not.toBe(hex(await b.epoch()))
+  })
+
+  it('gives the empty set an epoch of its own', async () => {
+    const empty = new ValidatorSet()
+    const one = new ValidatorSet([k1])
+    expect(hex(await empty.epoch())).not.toBe(hex(await one.epoch()))
+  })
+})

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,8 +28,8 @@ Failed transactions do not throw — they return `status: 'revert'` receipts wit
 
 - **Everything is async.** Hashing goes through `crypto.subtle`, so `hash`, `merkleRoot`, `stateRoot`, and every state-machine call return promises.
 - **The first byte of `tx.data` selects the transaction type.** Empty `data` defaults to `Transfer`. Only `Transfer` (0x01) and `ReputationAttest` (0x02) execute real logic today; every other `TransactionType` value is a placeholder that just increments the sender's nonce.
-- **`InMemoryStateStore.root()` is a flat hash of all entries, not a Merkle trie.** It's deterministic and good for equality checks across nodes, but it cannot produce inclusion proofs.
-- **Byte-identity everywhere.** Addresses are 32-byte public keys as `Uint8Array`s; account state lives under namespaced keys like `'account:' + pubkey`. Seed genesis balances with `encodeAccount` + `store.put` (see [`examples/02-state-machine.mjs`](https://github.com/johnhenry/raijin/blob/main/examples/02-state-machine.mjs)).
+- **`InMemoryStateStore.root()` is a Merkle root over the store's entries.** Each key→value pair is hashed through `encodeStateEntry` (domain-tagged, both fields length-prefixed) and the entry hashes are combined with `merkleRoot`, ordered by the key's bytes. It uniquely commits to the store's contents — but there is still no inclusion-proof API, so it is a commitment, not a queryable trie.
+- **Byte-identity everywhere.** Addresses are 32-byte public keys as `Uint8Array`s; account state lives under namespaced keys. Build those keys with `accountKey(address)` — never by concatenating a prefix yourself, since the key bytes are hashed into the state root. Seed genesis balances with `accountKey` + `encodeAccount` + `store.put` (see [`examples/02-state-machine.mjs`](https://github.com/johnhenry/raijin/blob/main/examples/02-state-machine.mjs)).
 
 ## API
 
@@ -73,25 +73,44 @@ toHex(root) // '9c31…'
 ```
 
 - `hash(data)` / `hashString(str)` — SHA-256, returns 32 bytes.
-- `merkleRoot(leaves)` — binary tree over leaf hashes; odd levels duplicate the last leaf. A single leaf is returned **as-is** (no extra hash), and `[]` yields `hash(empty)`. There is no leaf/node domain separation — don't use this where second-preimage games matter.
+- `merkleRoot(leaves)` — binary tree over leaf hashes, domain-separated: leaves are `H(0x00 ‖ leaf)`, internal nodes `H(0x01 ‖ left ‖ right)`. An odd level **promotes** its last node rather than pairing it with itself, and `[]` yields `H(0x00)`. Together these make the root a unique commitment to the leaf list: without them the tree has the CVE-2012-2459 shape, where `[A, B, C]` pads to `[A, B, C, C]` and both produce the same root.
 - `equal(a, b)` — byte-wise comparison (not constant-time).
 - `toHex` / `fromHex` — lowercase hex round-trip.
 
-### Encoding — `encodeBigInt`, `decodeBigInt`, `encodeBytes`, `decodeBytes`, `encodeTx`, `encodeTxSigned`, `encodeAccount`, `decodeAccount`
+### Encoding — `encodeBigInt`, `decodeBigInt`, `encodeBytes`, `decodeBytes`, `encodeTx`, `encodeTxSigned`, `encodeAccount`, `decodeAccount`, `encodeReceipt`, `encodeStateEntry`, `encodeBlockHeader`, `blockHash`, `Domain`
 
-Deterministic canonical binary encoding (LEB128 varints + length prefixes). `encodeTx(tx)` covers everything **except** the signature — it's the exact byte string that gets signed and that receipts hash. `encodeTxSigned(tx)` appends the signature and is what block producers hash for the tx Merkle root. The decoders return `[value, bytesConsumed]` pairs.
+Deterministic canonical binary encoding. Two rules hold throughout, and they are what make an encoding a *commitment* rather than merely a serialization:
+
+1. **Every variable-length field carries its length** (LEB128), so concatenation never loses the boundary between adjacent fields.
+2. **Every distinct structure carries a one-byte domain tag**, so one kind of encoding cannot be reinterpreted as another. The tags live in the `Domain` registry: `Transaction` 0x01, `SignedTransaction` 0x02, `Account` 0x03, `Receipt` 0x04, `BlockHeader` 0x05, `StateEntry` 0x06, `StateKey` 0x07. They are consensus-critical — never reuse or renumber one.
+
+- `encodeTx(tx)` covers everything **except** the signature; it is the exact byte string that gets signed.
+- `encodeTxSigned(tx)` wraps that plus the signature, and its hash is the canonical transaction identifier — block `txRoot` leaves, mempool dedup keys, and the `txHash` on every receipt.
+- `encodeBlockHeader(header)` / `blockHash(block)` — one definition of a header's bytes, used both for the consensus digest and for the block hash a child's `parentHash` must equal. `blockHash` is `H(encodeBlockHeader(header))`.
+- `encodeStateEntry(key, value)` — exported so that *any* `StateStore` implementation derives the same state root from the same contents. A store that invents its own layout forks from the ones that don't.
+- `decodeAccount` rejects bytes that are not tagged `Domain.Account` rather than misreading them.
+- The decoders return `[value, bytesConsumed]` pairs.
+
+### State keys — `accountKey`, `stateKey`, `StateNamespace`
+
+A state key is `0x07 ‖ len(namespace) ‖ namespace ‖ len(id) ‖ id`. Key bytes are hashed into the state root, so anything writing state directly — genesis funding, fixtures, a state-sync importer — must produce byte-identical keys or it silently forks from its peers.
+
+- `accountKey(address)` — where an account record lives. This is the one you want.
+- `stateKey(namespace, id)` — the general form, for the other `StateNamespace` entries.
+- `StateNamespace` — `account:`, `credential:`, `proposal:`, `service:`, `identity:`, `escrow:`, `validator:`. Only `account:` is read or written by the state machine today.
+
+Length-prefixing matters here even though the shipped namespaces happen not to collide: prefix-freeness and fixed-width ids are coincidences, not invariants, and a bare `namespace ‖ id` concatenation would let two different pairs land on one key. Keys within a namespace still share a prefix and sort together.
 
 ### Genesis funding
 
-There is no genesis-block concept — initial state is whatever you write to the store before the first block. Accounts live under the `'account:'` namespace:
+There is no genesis-block concept — initial state is whatever you write to the store before the first block. Accounts live under the `account:` namespace; use `accountKey` to build the key rather than concatenating the prefix by hand:
 
 ```js
-import { InMemoryStateStore, encodeAccount } from '@johnhenry/raijin-core'
+import { InMemoryStateStore, encodeAccount, accountKey } from '@johnhenry/raijin-core'
 
 const store = new InMemoryStateStore()
-const prefix = new TextEncoder().encode('account:')
 await store.put(
-  new Uint8Array([...prefix, ...alicePublicKey]),
+  accountKey(alicePublicKey),
   encodeAccount({ balance: 1_000n, nonce: 0n, reputation: 0n }),
 )
 ```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-core",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "State machine, blocks, and transactions for the Raijin mesh rollup",
   "repository": {
     "type": "git",

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -43,6 +43,7 @@ export const Domain = {
   Receipt: 0x04,
   BlockHeader: 0x05,
   StateEntry: 0x06,
+  StateKey: 0x07,
 } as const
 
 export type DomainTag = (typeof Domain)[keyof typeof Domain]

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Transaction, Block, BlockHeader, Account, TransactionReceipt } from './types.js'
+import { hash } from './hash.js'
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
@@ -136,4 +137,55 @@ export function encodeReceipt(receipt: TransactionReceipt): Uint8Array {
     pos += part.length
   }
   return result
+}
+
+// ── Block header encoding ─────────────────────────────────────────────
+
+/** Big-endian 8-byte encoding of a bigint, for fixed-width header fields. */
+function u64(value: bigint): Uint8Array {
+  const hex = value.toString(16).padStart(16, '0')
+  const bytes = new Uint8Array(8)
+  for (let i = 0; i < 8; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/**
+ * Deterministic bytes for a block header.
+ *
+ * One definition, used both for the consensus digest and for the block hash
+ * that links a block to its child -- if those two ever disagree, nodes are
+ * agreeing on one thing and chaining another.
+ */
+export function encodeBlockHeader(header: BlockHeader): Uint8Array {
+  const parts: Uint8Array[] = [
+    u64(header.number),
+    header.parentHash,
+    header.stateRoot,
+    header.txRoot,
+    header.receiptRoot,
+    u64(BigInt(header.timestamp)),
+    header.proposer,
+  ]
+  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
+  const result = new Uint8Array(totalLen)
+  let pos = 0
+  for (const part of parts) {
+    result.set(part, pos)
+    pos += part.length
+  }
+  return result
+}
+
+/**
+ * The canonical hash of a block: SHA-256 over its encoded header.
+ *
+ * This is what a child block's `parentHash` must be. It commits to the
+ * transactions (via `txRoot`), the execution result (`stateRoot`,
+ * `receiptRoot`), the proposer and the timestamp, so "same height, different
+ * history" is detectable from the headers alone.
+ */
+export async function blockHash(block: Block): Promise<Uint8Array> {
+  return hash(encodeBlockHeader(block.header))
 }

--- a/packages/core/src/encoding.ts
+++ b/packages/core/src/encoding.ts
@@ -2,13 +2,50 @@
  * Canonical binary encoding for transactions and blocks.
  * Deterministic — same input always produces same bytes.
  * Zero dependencies.
+ *
+ * Two rules hold everywhere in this file, and they are what make an encoding
+ * a *commitment* rather than merely a serialization:
+ *
+ * 1. **Every variable-length field carries its length.** Without a prefix,
+ *    concatenation loses the boundary between adjacent fields and two
+ *    different structures can flatten to the same bytes — the shape that made
+ *    `{key: 0xab, value: "cd"}` and `{key: 0xabcd, value: ""}` share a state
+ *    root, and that let a header with a 33-byte parentHash impersonate one
+ *    with a 32-byte parentHash and a longer state root.
+ * 2. **Every distinct structure carries a domain tag.** Without one, an
+ *    encoding of one kind of thing can be reinterpreted as an encoding of
+ *    another, so a signature or a Merkle leaf proves less than it appears to.
+ *
+ * `merkleRoot` in `hash.ts` follows the same convention (`0x00` leaves,
+ * `0x01` internal nodes).
  */
 
 import type { Transaction, Block, BlockHeader, Account, TransactionReceipt } from './types.js'
 import { hash } from './hash.js'
+import { RaijinError } from './errors.js'
 
 const encoder = new TextEncoder()
-const decoder = new TextDecoder()
+
+// ── Domain separation ─────────────────────────────────────────────────
+
+/**
+ * One byte at the front of every canonically encoded structure, so no
+ * structure's encoding can be read as another's.
+ *
+ * These bytes are consensus-critical: changing one changes every hash,
+ * signature and root derived from that structure. Add new kinds with new
+ * values; never reuse or renumber an existing one.
+ */
+export const Domain = {
+  Transaction: 0x01,
+  SignedTransaction: 0x02,
+  Account: 0x03,
+  Receipt: 0x04,
+  BlockHeader: 0x05,
+  StateEntry: 0x06,
+} as const
+
+export type DomainTag = (typeof Domain)[keyof typeof Domain]
 
 // ── Primitive encoders ────────────────────────────────────────────────
 
@@ -58,19 +95,26 @@ export function decodeBytes(data: Uint8Array, offset = 0): [Uint8Array, number] 
   return [data.slice(start, end), lenSize + Number(len)]
 }
 
-// ── Transaction encoding ──────────────────────────────────────────────
+/**
+ * Encode an optional byte string: `0x00` when absent, `0x01` followed by the
+ * length-prefixed bytes when present.
+ *
+ * "Absent" and "present but empty" are different values and must encode
+ * differently — `to: null` (a system operation) is not `to: new
+ * Uint8Array(0)` (a transfer to the empty address), and they used to sign the
+ * same bytes.
+ */
+function encodeOptionalBytes(data: Uint8Array | null | undefined): Uint8Array {
+  if (data === null || data === undefined) return new Uint8Array([0x00])
+  const body = encodeBytes(data)
+  const result = new Uint8Array(1 + body.length)
+  result[0] = 0x01
+  result.set(body, 1)
+  return result
+}
 
-/** Encode a transaction into deterministic bytes (for hashing/signing). */
-export function encodeTx(tx: Transaction): Uint8Array {
-  const parts: Uint8Array[] = [
-    encodeBytes(tx.from),
-    encodeBigInt(tx.nonce),
-    encodeBytes(tx.to ?? new Uint8Array(0)),
-    encodeBigInt(tx.value),
-    encodeBytes(tx.data),
-    encodeBigInt(tx.chainId),
-  ]
-  // Concatenate
+/** Concatenate parts, the first of which is conventionally the domain tag. */
+function concat(parts: Uint8Array[]): Uint8Array {
   const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
   const result = new Uint8Array(totalLen)
   let pos = 0
@@ -81,38 +125,70 @@ export function encodeTx(tx: Transaction): Uint8Array {
   return result
 }
 
+/**
+ * Big-endian 8-byte encoding of a bigint, for fixed-width fields.
+ *
+ * Fixed width is only unambiguous inside its range: a value that does not fit
+ * used to be silently truncated to its *high* 8 bytes, so two different block
+ * numbers could encode identically. Out of range is an error instead.
+ */
+function u64(value: bigint): Uint8Array {
+  if (value < 0n || value > 0xffff_ffff_ffff_ffffn) {
+    throw new RaijinError(`u64 out of range: ${value}`)
+  }
+  const hex = value.toString(16).padStart(16, '0')
+  const bytes = new Uint8Array(8)
+  for (let i = 0; i < 8; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+// ── Transaction encoding ──────────────────────────────────────────────
+
+/** Encode a transaction into deterministic bytes (for hashing/signing). */
+export function encodeTx(tx: Transaction): Uint8Array {
+  return concat([
+    new Uint8Array([Domain.Transaction]),
+    encodeBytes(tx.from),
+    encodeBigInt(tx.nonce),
+    encodeOptionalBytes(tx.to),
+    encodeBigInt(tx.value),
+    encodeBytes(tx.data),
+    encodeBigInt(tx.chainId),
+  ])
+}
+
 /** Encode a transaction including its signature. */
 export function encodeTxSigned(tx: Transaction): Uint8Array {
-  const body = encodeTx(tx)
-  const sig = encodeBytes(tx.signature)
-  const result = new Uint8Array(body.length + sig.length)
-  result.set(body, 0)
-  result.set(sig, body.length)
-  return result
+  return concat([
+    new Uint8Array([Domain.SignedTransaction]),
+    encodeTx(tx),
+    encodeBytes(tx.signature),
+  ])
 }
 
 // ── Account encoding ──────────────────────────────────────────────────
 
 /** Encode an account to bytes. */
 export function encodeAccount(account: Account): Uint8Array {
-  const parts = [
+  return concat([
+    new Uint8Array([Domain.Account]),
     encodeBigInt(account.balance),
     encodeBigInt(account.nonce),
     encodeBigInt(account.reputation),
-  ]
-  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-  const result = new Uint8Array(totalLen)
-  let pos = 0
-  for (const part of parts) {
-    result.set(part, pos)
-    pos += part.length
-  }
-  return result
+  ])
 }
 
-/** Decode an account from bytes. */
+/** Decode an account from bytes. Rejects bytes that encode something else. */
 export function decodeAccount(data: Uint8Array): Account {
-  let offset = 0
+  if (data.length === 0 || data[0] !== Domain.Account) {
+    throw new RaijinError(
+      `Not an account encoding: expected domain tag 0x${Domain.Account.toString(16).padStart(2, '0')}, ` +
+        `got ${data.length === 0 ? 'empty input' : `0x${data[0].toString(16).padStart(2, '0')}`}`,
+    )
+  }
+  let offset = 1
   const [balance, s1] = decodeBigInt(data, offset); offset += s1
   const [nonce, s2] = decodeBigInt(data, offset); offset += s2
   const [reputation, s3] = decodeBigInt(data, offset); offset += s3
@@ -123,33 +199,31 @@ export function decodeAccount(data: Uint8Array): Account {
 
 /** Encode a transaction receipt into deterministic bytes (for receipt-root hashing). */
 export function encodeReceipt(receipt: TransactionReceipt): Uint8Array {
-  const parts: Uint8Array[] = [
+  return concat([
+    new Uint8Array([Domain.Receipt]),
     encodeBytes(receipt.txHash),
     new Uint8Array([receipt.status === 'success' ? 1 : 0]),
-    encodeBytes(encoder.encode(receipt.revertReason ?? '')),
+    encodeOptionalBytes(
+      receipt.revertReason === undefined ? null : encoder.encode(receipt.revertReason),
+    ),
     encodeBigInt(BigInt(receipt.index)),
-  ]
-  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-  const result = new Uint8Array(totalLen)
-  let pos = 0
-  for (const part of parts) {
-    result.set(part, pos)
-    pos += part.length
-  }
-  return result
+  ])
+}
+
+// ── State entry encoding ──────────────────────────────────────────────
+
+/**
+ * Deterministic bytes for one key→value pair of the state store.
+ *
+ * Exported so that any `StateStore` implementation — in-memory, IndexedDB,
+ * OPFS — derives the same state root from the same contents. A store that
+ * invents its own layout forks the chain from the ones that don't.
+ */
+export function encodeStateEntry(key: Uint8Array, value: Uint8Array): Uint8Array {
+  return concat([new Uint8Array([Domain.StateEntry]), encodeBytes(key), encodeBytes(value)])
 }
 
 // ── Block header encoding ─────────────────────────────────────────────
-
-/** Big-endian 8-byte encoding of a bigint, for fixed-width header fields. */
-function u64(value: bigint): Uint8Array {
-  const hex = value.toString(16).padStart(16, '0')
-  const bytes = new Uint8Array(8)
-  for (let i = 0; i < 8; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  }
-  return bytes
-}
 
 /**
  * Deterministic bytes for a block header.
@@ -157,25 +231,24 @@ function u64(value: bigint): Uint8Array {
  * One definition, used both for the consensus digest and for the block hash
  * that links a block to its child -- if those two ever disagree, nodes are
  * agreeing on one thing and chaining another.
+ *
+ * The four roots and the proposer key are length-prefixed. Nothing in the
+ * type system pins them to 32 bytes, and unprefixed concatenation let a
+ * header with a short parentHash and a long stateRoot produce the same bytes
+ * — and so the same digest and the same block hash — as a header that split
+ * those bytes differently.
  */
 export function encodeBlockHeader(header: BlockHeader): Uint8Array {
-  const parts: Uint8Array[] = [
+  return concat([
+    new Uint8Array([Domain.BlockHeader]),
     u64(header.number),
-    header.parentHash,
-    header.stateRoot,
-    header.txRoot,
-    header.receiptRoot,
+    encodeBytes(header.parentHash),
+    encodeBytes(header.stateRoot),
+    encodeBytes(header.txRoot),
+    encodeBytes(header.receiptRoot),
     u64(BigInt(header.timestamp)),
-    header.proposer,
-  ]
-  const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-  const result = new Uint8Array(totalLen)
-  let pos = 0
-  for (const part of parts) {
-    result.set(part, pos)
-    pos += part.length
-  }
-  return result
+    encodeBytes(header.proposer),
+  ])
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,8 @@ export {
   encodeAccount,
   decodeAccount,
   encodeReceipt,
+  encodeBlockHeader,
+  blockHash,
 } from './encoding.js'
 
 // Cryptography

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,10 @@ export { TransactionType } from './types.js'
 // State machine
 export { StateMachine } from './state-machine.js'
 
+// State keys — the canonical layout for anything writing state directly
+// (genesis funding, fixtures, state sync). See `stateKey`'s docs.
+export { StateNamespace, stateKey, accountKey } from './state-machine.js'
+
 // State store
 export { InMemoryStateStore } from './state.js'
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export { InMemoryStateStore } from './state.js'
 export { hash, hashString, merkleRoot, equal, toHex, fromHex } from './hash.js'
 
 // Encoding
+export { Domain, type DomainTag } from './encoding.js'
 export {
   encodeBigInt,
   decodeBigInt,
@@ -40,6 +41,7 @@ export {
   encodeAccount,
   decodeAccount,
   encodeReceipt,
+  encodeStateEntry,
   encodeBlockHeader,
   blockHash,
 } from './encoding.js'

--- a/packages/core/src/state-machine.ts
+++ b/packages/core/src/state-machine.ts
@@ -14,13 +14,28 @@ import type {
 } from './types.js'
 import { TransactionType } from './types.js'
 import { hash, merkleRoot } from './hash.js'
-import { encodeTx, encodeTxSigned, encodeAccount, decodeAccount } from './encoding.js'
+import {
+  encodeTx,
+  encodeTxSigned,
+  encodeAccount,
+  decodeAccount,
+  encodeBytes,
+  Domain,
+} from './encoding.js'
 
 const EMPTY_ACCOUNT: Account = { balance: 0n, nonce: 0n, reputation: 0n }
 const encoder = new TextEncoder()
 
-/** Namespace prefixes for state keys. */
-const NS = {
+/**
+ * Namespace prefixes for state keys.
+ *
+ * Exported because a state key's bytes are consensus-critical: every key is
+ * hashed into the state root, so anything that writes state directly — genesis
+ * funding, a test fixture, a state-sync importer — must produce byte-identical
+ * keys or the node silently forks from its peers at the first root comparison.
+ * Build keys with `accountKey`/`stateKey`, never by concatenating by hand.
+ */
+export const StateNamespace = {
   account: encoder.encode('account:'),
   credential: encoder.encode('credential:'),
   proposal: encoder.encode('proposal:'),
@@ -30,12 +45,44 @@ const NS = {
   validator: encoder.encode('validator:'),
 } as const
 
-/** Build a namespaced state key. */
-function stateKey(namespace: Uint8Array, id: Uint8Array): Uint8Array {
-  const key = new Uint8Array(namespace.length + id.length)
-  key.set(namespace, 0)
-  key.set(id, namespace.length)
+/**
+ * Build a namespaced state key: `0x07 ‖ len(namespace) ‖ namespace ‖ len(id) ‖ id`.
+ *
+ * This used to be the bare concatenation `namespace ‖ id`, which was
+ * unambiguous only by coincidence. Two coincidences, in fact, and neither is
+ * enforced anywhere: that the namespaces defined above happen to be
+ * prefix-free (they differ in their first byte — a, c, p, s, i, e, v), and
+ * that every id in use happens to be a fixed-width 32-byte public key.
+ * Neither the `Uint8Array` type nor any runtime check holds either property.
+ * Add a namespace whose name extends another's, or a variable-length id, and
+ * `ns₁ ‖ id₁` can equal `ns₂ ‖ id₂` for different pairs — two different pieces
+ * of state at one key, and a state root that no longer says which one it
+ * committed to.
+ *
+ * Length-prefixing removes the coincidence: each field is self-delimiting, so
+ * distinct `(namespace, id)` pairs always produce distinct keys. The domain
+ * tag keeps a state key from colliding with any other encoded structure. Keys
+ * within one namespace still share a common prefix and so still sort and scan
+ * together, because a namespace's own length is fixed.
+ */
+export function stateKey(namespace: Uint8Array, id: Uint8Array): Uint8Array {
+  const ns = encodeBytes(namespace)
+  const body = encodeBytes(id)
+  const key = new Uint8Array(1 + ns.length + body.length)
+  key[0] = Domain.StateKey
+  key.set(ns, 1)
+  key.set(body, 1 + ns.length)
   return key
+}
+
+/**
+ * The state key an account record lives under.
+ *
+ * This is the key genesis funding must write to — see the "Genesis funding"
+ * section of the package README.
+ */
+export function accountKey(address: Uint8Array): Uint8Array {
+  return stateKey(StateNamespace.account, address)
 }
 
 /**
@@ -53,7 +100,7 @@ export class StateMachine {
 
   /** Get an account from state, returning a zero account if not found. */
   async getAccount(address: Uint8Array): Promise<Account> {
-    const key = stateKey(NS.account, address)
+    const key = accountKey(address)
     const data = await this.#store.get(key)
     if (!data) return { ...EMPTY_ACCOUNT }
     return decodeAccount(data)
@@ -61,7 +108,7 @@ export class StateMachine {
 
   /** Write an account to state. */
   async #putAccount(address: Uint8Array, account: Account): Promise<void> {
-    const key = stateKey(NS.account, address)
+    const key = accountKey(address)
     await this.#store.put(key, encodeAccount(account))
   }
 

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -4,7 +4,8 @@
  */
 
 import type { StateStore, StateSnapshot } from './types.js'
-import { hash, equal } from './hash.js'
+import { hash, merkleRoot, fromHex } from './hash.js'
+import { encodeStateEntry } from './encoding.js'
 
 /**
  * In-memory state store backed by a sorted Map.
@@ -34,30 +35,34 @@ export class InMemoryStateStore implements StateStore {
     this.#data.delete(this.keyToString(key))
   }
 
+  /**
+   * Merkle root over every key→value pair, in key order.
+   *
+   * This used to be `H(key0 || value0 || key1 || value1 || ...)` with no
+   * length prefix on anything, so the root did not commit to where one field
+   * ended and the next began: a store holding key `0xab` with value `"cd"`
+   * and a store holding key `0xabcd` with an empty value flattened to the
+   * same bytes and produced the same root. A state root that two different
+   * states can share proves nothing about the state — and it is the value a
+   * block header carries.
+   *
+   * Each entry is now hashed through `encodeStateEntry` (domain-tagged,
+   * both fields length-prefixed) and the entry hashes are combined with
+   * `merkleRoot`, which is itself collision-resistant across leaf lists.
+   *
+   * Ordering is by the key's bytes, not `localeCompare`: locale-sensitive
+   * comparison is a property of the runtime, and two nodes that disagree
+   * about it would order the same state differently and derive different
+   * roots from identical data.
+   */
   async root(): Promise<Uint8Array> {
-    // Sort keys for determinism, then hash all key-value pairs
-    const entries = [...this.#data.entries()].sort(([a], [b]) => a.localeCompare(b))
+    const entries = [...this.#data.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
 
-    if (entries.length === 0) {
-      return hash(new Uint8Array(0))
-    }
+    const leaves = await Promise.all(
+      entries.map(([key, value]) => hash(encodeStateEntry(fromHex(key), value))),
+    )
 
-    // Concatenate all key-value pairs and hash
-    const parts: Uint8Array[] = []
-    for (const [key, value] of entries) {
-      const keyBytes = new TextEncoder().encode(key)
-      parts.push(keyBytes, value)
-    }
-
-    const totalLen = parts.reduce((sum, p) => sum + p.length, 0)
-    const combined = new Uint8Array(totalLen)
-    let pos = 0
-    for (const part of parts) {
-      combined.set(part, pos)
-      pos += part.length
-    }
-
-    return hash(combined)
+    return merkleRoot(leaves)
   }
 
   async snapshot(): Promise<StateSnapshot> {

--- a/packages/core/test/encoding.test.ts
+++ b/packages/core/test/encoding.test.ts
@@ -10,6 +10,9 @@ import {
   encodeTxSigned,
   encodeReceipt,
   encodeStateEntry,
+  stateKey,
+  accountKey,
+  StateNamespace,
   encodeBlockHeader,
   toHex,
   Domain,
@@ -194,5 +197,31 @@ describe('canonical encoding — injectivity', () => {
   it('tags each structure with a distinct domain byte', () => {
     const tags = Object.values(Domain)
     expect(new Set(tags).size).toBe(tags.length)
+  })
+
+  it('gives two state keys that split the same bytes differently different keys', () => {
+    // The bare `namespace ‖ id` concatenation this replaced was unambiguous
+    // only because the shipped namespaces happen to be prefix-free and every
+    // id happens to be 32 bytes. Neither is enforced, so the encoding must
+    // not depend on either.
+    const a = stateKey(new Uint8Array([0x61, 0x62]), new Uint8Array([0x63]))
+    const b = stateKey(new Uint8Array([0x61]), new Uint8Array([0x62, 0x63]))
+    expect(toHex(a)).not.toBe(toHex(b))
+  })
+
+  it('keeps keys in one namespace under a common, sortable prefix', () => {
+    // Length-prefixing must not scatter a namespace: a namespace's own length
+    // is fixed, so every key in it still shares a prefix and sorts together.
+    const one = toHex(accountKey(new Uint8Array(32).fill(1)))
+    const two = toHex(accountKey(new Uint8Array(32).fill(2)))
+    const other = toHex(stateKey(StateNamespace.validator, new Uint8Array(32).fill(1)))
+    const shared = toHex(stateKey(StateNamespace.account, new Uint8Array(0))).slice(0, 20)
+    expect(one.startsWith(shared)).toBe(true)
+    expect(two.startsWith(shared)).toBe(true)
+    expect(other.startsWith(shared)).toBe(false)
+  })
+
+  it('domain-tags a state key so it cannot be read as another structure', () => {
+    expect(accountKey(new Uint8Array(32))[0]).toBe(Domain.StateKey)
   })
 })

--- a/packages/core/test/encoding.test.ts
+++ b/packages/core/test/encoding.test.ts
@@ -6,6 +6,15 @@ import {
   decodeBytes,
   encodeAccount,
   decodeAccount,
+  encodeTx,
+  encodeTxSigned,
+  encodeReceipt,
+  encodeStateEntry,
+  encodeBlockHeader,
+  toHex,
+  Domain,
+  type Transaction,
+  type BlockHeader,
 } from '../src/index.js'
 
 describe('encoding', () => {
@@ -84,5 +93,106 @@ describe('encoding', () => {
       expect(decoded.nonce).toBe(999999n)
       expect(decoded.reputation).toBe(2n ** 32n)
     })
+  })
+})
+
+// ── Collision resistance of the canonical encodings ───────────────────
+//
+// Every encoding here is hashed, signed, or both. The property under test is
+// injectivity: two different structures must never produce the same bytes,
+// and one kind of structure must never produce bytes readable as another.
+
+describe('canonical encoding — injectivity', () => {
+  function makeTx(overrides: Partial<Transaction> = {}): Transaction {
+    return {
+      from: new Uint8Array(32).fill(1),
+      nonce: 0n,
+      to: new Uint8Array(32).fill(2),
+      value: 100n,
+      data: new Uint8Array([1]),
+      signature: new Uint8Array(64),
+      chainId: 1n,
+      ...overrides,
+    }
+  }
+
+  function makeHeader(overrides: Partial<BlockHeader> = {}): BlockHeader {
+    return {
+      number: 1n,
+      parentHash: new Uint8Array(32).fill(0xaa),
+      stateRoot: new Uint8Array(32).fill(0xbb),
+      txRoot: new Uint8Array(32).fill(0xcc),
+      receiptRoot: new Uint8Array(32).fill(0xdd),
+      timestamp: 1_700_000_000_000,
+      proposer: new Uint8Array(32).fill(0xee),
+      ...overrides,
+    }
+  }
+
+  it('distinguishes a transaction with no recipient from one sent to the empty address', () => {
+    // `to: null` means a system operation; `to: new Uint8Array(0)` is a
+    // transfer to a zero-length address. Both used to encode as an empty
+    // length-prefixed field, so one signature covered both readings.
+    const system = encodeTx(makeTx({ to: null }))
+    const empty = encodeTx(makeTx({ to: new Uint8Array(0) }))
+    expect(toHex(system)).not.toBe(toHex(empty))
+  })
+
+  it('keeps a signed transaction from being read as an unsigned one', () => {
+    const tx = makeTx()
+    expect(encodeTx(tx)[0]).toBe(Domain.Transaction)
+    expect(encodeTxSigned(tx)[0]).toBe(Domain.SignedTransaction)
+    expect(toHex(encodeTxSigned(tx))).not.toBe(toHex(encodeTx(tx)))
+  })
+
+  it('refuses to decode a non-account encoding as an account', () => {
+    const receiptBytes = encodeReceipt({
+      txHash: new Uint8Array(32),
+      status: 'success',
+      index: 0,
+    })
+    expect(() => decodeAccount(receiptBytes)).toThrow(/domain tag/)
+    expect(() => decodeAccount(new Uint8Array(0))).toThrow(/domain tag/)
+    // The real thing still round-trips.
+    expect(decodeAccount(encodeAccount({ balance: 5n, nonce: 1n, reputation: 2n })).balance).toBe(5n)
+  })
+
+  it('distinguishes a revert with no reason from a revert with an empty reason', () => {
+    const base = { txHash: new Uint8Array(32), status: 'revert' as const, index: 0 }
+    const noReason = encodeReceipt(base)
+    const emptyReason = encodeReceipt({ ...base, revertReason: '' })
+    expect(toHex(noReason)).not.toBe(toHex(emptyReason))
+  })
+
+  it('distinguishes two headers that differ only in where one root ends', () => {
+    // Nothing constrains these fields to 32 bytes at the type level. Without
+    // length prefixes, a 31-byte parentHash followed by a 33-byte stateRoot
+    // concatenated to exactly the same bytes as 32 and 32 — two different
+    // headers, one digest, one block hash.
+    const shifted = makeHeader({
+      parentHash: new Uint8Array(31).fill(0xaa),
+      stateRoot: new Uint8Array([0xaa, ...new Uint8Array(32).fill(0xbb)]),
+    })
+    const normal = makeHeader()
+
+    expect(toHex(encodeBlockHeader(shifted))).not.toBe(toHex(encodeBlockHeader(normal)))
+  })
+
+  it('rejects a block number or timestamp that does not fit its fixed-width field', () => {
+    // Out of range used to be silently truncated to the high 8 bytes, so two
+    // different block numbers encoded identically.
+    expect(() => encodeBlockHeader(makeHeader({ number: 2n ** 64n }))).toThrow(/out of range/)
+    expect(() => encodeBlockHeader(makeHeader({ number: 2n ** 64n - 1n }))).not.toThrow()
+  })
+
+  it('gives two state entries that split the same bytes differently different encodings', () => {
+    const a = encodeStateEntry(new Uint8Array([0xab]), new Uint8Array([0xcd]))
+    const b = encodeStateEntry(new Uint8Array([0xab, 0xcd]), new Uint8Array(0))
+    expect(toHex(a)).not.toBe(toHex(b))
+  })
+
+  it('tags each structure with a distinct domain byte', () => {
+    const tags = Object.values(Domain)
+    expect(new Set(tags).size).toBe(tags.length)
   })
 })

--- a/packages/core/test/state-machine.test.ts
+++ b/packages/core/test/state-machine.test.ts
@@ -3,6 +3,7 @@ import {
   StateMachine,
   InMemoryStateStore,
   TransactionType,
+  accountKey,
   encodeTx,
   hash,
   type Transaction,
@@ -84,10 +85,7 @@ describe('StateMachine', () => {
       const root1 = await sm.stateRoot()
       // Fund alice directly in the store
       const { encodeAccount } = await import('../src/encoding.js')
-      const key = new TextEncoder().encode('account:')
-      const fullKey = new Uint8Array(key.length + alice.length)
-      fullKey.set(key, 0)
-      fullKey.set(alice, key.length)
+      const fullKey = accountKey(alice)
       await store.put(fullKey, encodeAccount({ balance: 100n, nonce: 0n, reputation: 0n }))
       const root2 = await sm.stateRoot()
       expect(root1).not.toEqual(root2)
@@ -98,10 +96,7 @@ describe('StateMachine', () => {
     beforeEach(async () => {
       // Fund alice with 1000
       const { encodeAccount } = await import('../src/encoding.js')
-      const key = new TextEncoder().encode('account:')
-      const fullKey = new Uint8Array(key.length + alice.length)
-      fullKey.set(key, 0)
-      fullKey.set(alice, key.length)
+      const fullKey = accountKey(alice)
       await store.put(fullKey, encodeAccount({ balance: 1000n, nonce: 0n, reputation: 0n }))
     })
 
@@ -183,10 +178,7 @@ describe('StateMachine', () => {
   describe('reputation attestation', () => {
     beforeEach(async () => {
       const { encodeAccount } = await import('../src/encoding.js')
-      const key = new TextEncoder().encode('account:')
-      const fullKey = new Uint8Array(key.length + alice.length)
-      fullKey.set(key, 0)
-      fullKey.set(alice, key.length)
+      const fullKey = accountKey(alice)
       await store.put(fullKey, encodeAccount({ balance: 100n, nonce: 0n, reputation: 10n }))
     })
 
@@ -216,10 +208,7 @@ describe('StateMachine', () => {
   describe('applyBlock', () => {
     beforeEach(async () => {
       const { encodeAccount } = await import('../src/encoding.js')
-      const key = new TextEncoder().encode('account:')
-      const fullKey = new Uint8Array(key.length + alice.length)
-      fullKey.set(key, 0)
-      fullKey.set(alice, key.length)
+      const fullKey = accountKey(alice)
       await store.put(fullKey, encodeAccount({ balance: 1000n, nonce: 0n, reputation: 5n }))
     })
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { InMemoryStateStore, StateMachine, equal, toHex, fromHex } from '../src/index.js'
+
+const encoder = new TextEncoder()
+
+async function storeWith(entries: [Uint8Array, Uint8Array][]): Promise<InMemoryStateStore> {
+  const store = new InMemoryStateStore()
+  for (const [key, value] of entries) await store.put(key, value)
+  return store
+}
+
+describe('InMemoryStateStore.root', () => {
+  it('gives two different states two different roots when a byte moves across the key/value boundary', async () => {
+    // The state root used to be `H(key0 || value0 || key1 || value1 || ...)`
+    // over hex-encoded keys and raw values, with no length prefix on either.
+    // Nothing then marked where a key stopped and its value began, so bytes
+    // could be shifted across that boundary and the concatenation — and the
+    // root — stayed identical.
+    //
+    // Here: one entry under key 0xab whose value is the two ASCII bytes "cd",
+    // versus one entry under key 0xabcd with an empty value. Both used to
+    // flatten to the bytes 61 62 63 64 ("abcd").
+    const a = await storeWith([[fromHex('ab'), encoder.encode('cd')]])
+    const b = await storeWith([[fromHex('abcd'), new Uint8Array(0)]])
+
+    expect(equal(await a.root(), await b.root())).toBe(false)
+
+    // The same attack stated against the *current* encoding, which hashes raw
+    // key bytes rather than their hex text: a one-byte key with a one-byte
+    // value versus a two-byte key with an empty value. Only the length
+    // prefixes keep these apart.
+    const c = await storeWith([[fromHex('ab'), fromHex('cd')]])
+    const d = await storeWith([[fromHex('abcd'), new Uint8Array(0)]])
+
+    expect(equal(await c.root(), await d.root())).toBe(false)
+  })
+
+  it('gives two states with different account boundaries different roots', async () => {
+    // The same defect with two entries each, which is the shape a real store
+    // has: state keys are `namespace + id` and namespaces differ in length
+    // ('account:' is 8 bytes, 'credential:' is 11), while values are
+    // variable-length LEB128 records. Adjacent entries could therefore trade
+    // bytes between key and value and leave the root unchanged.
+    const a = await storeWith([
+      [fromHex('61'), encoder.encode('62')],
+      [fromHex('63'), encoder.encode('64')],
+    ])
+    const b = await storeWith([
+      [fromHex('6162'), new Uint8Array(0)],
+      [fromHex('6364'), new Uint8Array(0)],
+    ])
+
+    expect(equal(await a.root(), await b.root())).toBe(false)
+  })
+
+  it('separates the empty state from every non-empty state', async () => {
+    const empty = new InMemoryStateStore()
+    const one = await storeWith([[fromHex('00'), new Uint8Array(0)]])
+
+    expect(equal(await empty.root(), await one.root())).toBe(false)
+    // Stable across calls — the root is a function of the contents alone.
+    expect(toHex(await empty.root())).toBe(toHex(await new InMemoryStateStore().root()))
+  })
+
+  it('is insertion-order independent but content sensitive', async () => {
+    const forward = await storeWith([
+      [fromHex('01'), encoder.encode('one')],
+      [fromHex('02'), encoder.encode('two')],
+    ])
+    const reverse = await storeWith([
+      [fromHex('02'), encoder.encode('two')],
+      [fromHex('01'), encoder.encode('one')],
+    ])
+    expect(toHex(await forward.root())).toBe(toHex(await reverse.root()))
+
+    await reverse.put(fromHex('02'), encoder.encode('TWO'))
+    expect(equal(await forward.root(), await reverse.root())).toBe(false)
+  })
+
+  it('returns to the earlier root after a revert', async () => {
+    const store = new InMemoryStateStore()
+    await store.put(fromHex('01'), encoder.encode('one'))
+    const before = await store.root()
+
+    const snapshot = await store.snapshot()
+    await store.put(fromHex('02'), encoder.encode('two'))
+    expect(equal(await store.root(), before)).toBe(false)
+
+    await store.revert(snapshot)
+    expect(equal(await store.root(), before)).toBe(true)
+  })
+
+  it('distinguishes two account sets that differ only in where a key ends', async () => {
+    // Reached through the public state API rather than raw byte keys: two
+    // stores holding accounts under keys of different lengths. This is what a
+    // divergent chain would have looked like — two different sets of balances
+    // producing one stateRoot, so the header agreed on nothing.
+    const verifier = { async verify() { return true } }
+    const a = new InMemoryStateStore()
+    const b = new InMemoryStateStore()
+    const smA = new StateMachine(a, verifier)
+    const smB = new StateMachine(b, verifier)
+
+    // Store A: the account id ends at 'x', and the record's first bytes are
+    // the ASCII text "61". Store B: the id is one byte longer (0x61 = 'a')
+    // and the record is empty. Keys are hex-stringified before hashing, so
+    // A's value bytes were byte-identical to B's extra key nibble pair.
+    await a.put(encoder.encode('account:x'), encoder.encode('61'))
+    await b.put(encoder.encode('account:xa'), new Uint8Array(0))
+
+    // `stateRoot()` is exactly what goes into the block header.
+    expect(equal(await smA.stateRoot(), await smB.stateRoot())).toBe(false)
+  })
+})

--- a/packages/da/README.md
+++ b/packages/da/README.md
@@ -22,7 +22,9 @@ npm install @johnhenry/raijin-da
 Other traps:
 
 - **`EthBlobDA` throws on every method.** It exists to pin the interface and document the implementation path (viem blob transactions, KZG setup, Beacon API retrieval); the error messages are the TODO list. Ethereum blobs are also pruned after ~18 days — plan for archival.
-- **`encode()` output depends on the environment.** If the optional `fflate` package is importable, payloads that shrink get deflate-compressed with an `RJC` magic prefix; otherwise raw bytes with `RJR`. `decode()` of an `RJC` payload **throws if fflate is absent** — if writers may compress, every reader needs fflate too.
+- **`encode()` output depends on the environment.** If the optional `fflate` package is importable, payloads that shrink get deflate-compressed with an `RJC` magic prefix; otherwise raw bytes with `RJR`. `decode()` of an `RJC` payload throws if fflate is absent **and** no `inflate` was supplied — if writers may compress, every reader needs fflate or an explicit codec (`decode(data, { inflate })`).
+- **`decode()` caps its output at 16 MiB.** DA bytes are by definition untrusted, and DEFLATE reaches roughly 1000:1 on repetitive input, so a few kilobytes can ask for gigabytes. Oversized payloads are refused with `DASizeLimitError`. Raise it per call with `decode(data, { maxDecompressedSize })` if a payload is genuinely expected to be larger.
+- **`CelestiaDA` refuses to send an auth token over cleartext `http:`** to a non-loopback host — the node token is a node credential and usually carries write access. Use `https:`, a loopback host (the default `http://localhost:26658` is fine), or opt in explicitly with `allowInsecureAuth: true`.
 - **`CelestiaDA` needs a running light node** (default endpoint `http://localhost:26658`, usually with an auth token). It does not embed one.
 
 ## Quick start
@@ -46,8 +48,9 @@ import { CelestiaDA } from '@johnhenry/raijin-da'
 
 const da = new CelestiaDA({
   namespace: '00c0ffee00c0ffee',      // required, 8-byte hex namespace
-  endpoint: 'http://localhost:26658', // default
+  endpoint: 'http://localhost:26658', // default; loopback, so cleartext is OK
   authToken: process.env.CELESTIA_NODE_AUTH_TOKEN,
+  // allowInsecureAuth: true,         // only for a non-loopback http: endpoint
 })
 ```
 
@@ -72,15 +75,28 @@ In-memory, content-addressed blob store. `retrieve()` throws for unknown hashes;
 
 ### `CelestiaDA` / `CelestiaDAOptions`
 
-Client for the Celestia Node REST API (`submit_pfb`, `namespaced_data`). `submit()` posts to your namespace and returns the inclusion height; `retrieve()` scans the namespace at that height for a blob matching the commitment hash; `verify()` is retrieve-and-rehash (network errors ⇒ `false`, not an exception). Options: `namespace` (required), `endpoint`, `authToken`.
+Client for the Celestia Node REST API (`submit_pfb`, `namespaced_data`). `submit()` posts to your namespace and returns the inclusion height; `retrieve()` scans the namespace at that height for a blob matching the commitment hash; `verify()` is retrieve-and-rehash (network errors ⇒ `false`, not an exception). Options: `namespace` (required), `endpoint`, `authToken`, `allowInsecureAuth`.
+
+The constructor **throws** if an `authToken` is set and `endpoint` is `http:` on a non-loopback host, unless `allowInsecureAuth: true` is passed. The namespace is percent-encoded into the request path, so a caller-supplied namespace cannot rewrite the URL and carry the token to a different route.
 
 ### `EthBlobDA` / `EthBlobDAOptions`
 
 The stub. Options (`rpcUrl`, `beaconUrl`, `chainId`) are accepted and stored; `submit`/`retrieve`/`verify` throw with step-by-step implementation requirements. Read the source of `eth-blobs.ts` for a complete viem-based sketch.
 
-### `encode(data)` / `decode(data)`
+### `encode(data, opts?)` / `decode(data, opts?)`
 
-3-byte magic header (`RJC` compressed / `RJR` raw) + payload. Compression is used only when fflate is available **and** actually shrinks the payload. `decode()` throws on missing/unknown magic and on compressed data without fflate.
+Frame layout:
+
+- raw: `"RJR" ‖ data`
+- compressed: `"RJC" ‖ LEB128(decompressed length) ‖ deflate(data)`
+
+The compressed frame carries the **decompressed** length so `decode()` can refuse an oversized payload before allocating for it. Compression is used only when a deflater is available **and** the whole frame (length header included) actually shrinks the payload.
+
+`decode()` never returns more than `maxDecompressedSize` bytes (default `MAX_DECOMPRESSED_SIZE`, 16 MiB) — the declared length is checked against the cap before inflating, the inflater is then bounded by that declared length, and the result is checked again in case the inflater ignored its bound. Both branches are capped, so `decode` has one postcondition regardless of which frame it got.
+
+Errors: every rejection is a `DADecodeError` (missing/unknown magic, a truncated frame, a failure inside the compression library, which is wrapped rather than propagated raw), and size refusals are a `DASizeLimitError` subclass carrying `limit` and `requested`.
+
+Options: `encode(data, { deflate })` and `decode(data, { maxDecompressedSize, inflate })`. Supply a codec explicitly for environments where the optional fflate import does not resolve; an `Inflate` must honour its `limit` argument as a memory bound, not a post-hoc truncation.
 
 ## Wiring DA into a validator
 

--- a/packages/da/package.json
+++ b/packages/da/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-da",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Data availability abstraction with pluggable backends for the Raijin mesh rollup",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1"
   },
   "peerDependencies": {
     "viem": "^2"

--- a/packages/da/src/encoding.ts
+++ b/packages/da/src/encoding.ts
@@ -3,12 +3,105 @@
  *
  * Uses fflate for compression when available, falls back to raw bytes.
  * Zero hard dependencies — fflate is optional.
+ *
+ * ## Decompression is a trust boundary
+ *
+ * Everything `decode()` is handed came off a data availability layer, which
+ * is to say: off the network, from whoever chose to post it. DEFLATE reaches
+ * roughly 1000:1 on repetitive input, so a few kilobytes of attacker-chosen
+ * bytes can ask for gigabytes of output — a zip bomb, on exactly the data
+ * path that by definition carries untrusted bytes.
+ *
+ * Two things keep that bounded here, and the order matters:
+ *
+ * 1. **A compressed frame declares its decompressed length**, and `decode()`
+ *    checks that declaration against `maxDecompressedSize` *before* it
+ *    inflates anything. A bomb that asks for a gigabyte is refused without a
+ *    gigabyte ever being allocated.
+ * 2. **The inflater is given that length as a hard bound**, so a frame that
+ *    declares a small size and then streams more than it promised is stopped
+ *    inside the inflater rather than after the memory is already committed.
+ *
+ * The length check after inflation is a third, weaker net: by the time it can
+ * run, the allocation has happened. It is there to fail closed against an
+ * inflater that ignores its bound, not to provide the bound.
  */
+
+import { RaijinError } from '@johnhenry/raijin-core'
+import { encodeBigInt, decodeBigInt } from '@johnhenry/raijin-core'
+
+// ── Errors ────────────────────────────────────────────────────────────
+
+/**
+ * `decode()` refused a payload. Every rejection from `decode()` is one of
+ * these, including failures that originate inside the compression library —
+ * callers should not have to catch whatever the zlib layer happens to throw,
+ * or tell it apart from a bug in their own code.
+ */
+export class DADecodeError extends RaijinError {
+  constructor(reason: string, options?: { cause?: unknown }) {
+    super(`DA decode failed: ${reason}`)
+    this.name = 'DADecodeError'
+    if (options && 'cause' in options) {
+      // `cause` is not part of RaijinError's constructor; attach it directly
+      // so the underlying compression error is not lost.
+      Object.defineProperty(this, 'cause', {
+        value: options.cause,
+        configurable: true,
+        writable: true,
+      })
+    }
+  }
+}
+
+/**
+ * A payload asked to produce more than `maxDecompressedSize` bytes.
+ *
+ * Thrown for the zip-bomb case, and for a raw payload longer than the cap,
+ * so that `decode()` has a single postcondition: it never returns more than
+ * `maxDecompressedSize` bytes.
+ */
+export class DASizeLimitError extends DADecodeError {
+  /** The cap that was exceeded, in bytes. */
+  readonly limit: number
+  /** How many bytes the payload asked for, when that is known. */
+  readonly requested: number
+
+  constructor(requested: number, limit: number, what: string) {
+    super(
+      `${what} is ${requested} bytes, over the ${limit}-byte limit. ` +
+      'Raise maxDecompressedSize if this payload is genuinely expected.',
+    )
+    this.name = 'DASizeLimitError'
+    this.limit = limit
+    this.requested = requested
+  }
+}
+
+// ── Compression backend ───────────────────────────────────────────────
+
+/** Compress `data`. Must produce a raw DEFLATE stream. */
+export type Deflate = (data: Uint8Array) => Uint8Array
+
+/**
+ * Decompress `data`, producing at most `limit` bytes.
+ *
+ * `limit` is a memory bound, not a post-hoc assertion: an implementation
+ * must stop and throw once the output would exceed it. An implementation
+ * that inflates to completion and then truncates satisfies the signature
+ * and provides no protection at all.
+ */
+export type Inflate = (data: Uint8Array, limit: number) => Uint8Array
 
 /** Shape of the fflate subset we use. */
 interface FflateCompat {
   deflateSync: (data: Uint8Array) => Uint8Array
-  inflateSync: (data: Uint8Array) => Uint8Array
+  /**
+   * fflate will not grow an output buffer the caller supplies — it throws as
+   * soon as the stream needs more room than `out` has, which is what makes
+   * `out` a real bound rather than a hint.
+   */
+  inflateSync: (data: Uint8Array, opts?: { out?: Uint8Array }) => Uint8Array
 }
 
 /** Attempt to load fflate at module level. */
@@ -27,24 +120,79 @@ async function getFflate(): Promise<FflateCompat | null> {
   return _fflate
 }
 
+// ── Limits ────────────────────────────────────────────────────────────
+
+/**
+ * Default ceiling on what one `decode()` will produce: 16 MiB.
+ *
+ * A DA blob holds one rollup block's data. Celestia's practical per-blob
+ * ceiling is a couple of megabytes and an EIP-4844 blob is 128 KiB, so this
+ * leaves generous headroom while still bounding a single decode to something
+ * a browser tab can survive. Override it per call with
+ * `DecodeOptions.maxDecompressedSize`.
+ */
+export const MAX_DECOMPRESSED_SIZE = 16 * 1024 * 1024
+
+// ── Options ───────────────────────────────────────────────────────────
+
+export interface EncodeOptions {
+  /**
+   * Compressor to use. Defaults to fflate's `deflateSync` when fflate can be
+   * imported, and to no compression at all when it cannot.
+   */
+  deflate?: Deflate
+}
+
+export interface DecodeOptions {
+  /**
+   * Maximum number of bytes `decode()` may return. Default:
+   * `MAX_DECOMPRESSED_SIZE` (16 MiB). A payload that asks for more is
+   * refused with `DASizeLimitError`.
+   */
+  maxDecompressedSize?: number
+  /**
+   * Decompressor to use. Defaults to fflate's `inflateSync`, bounded with a
+   * caller-supplied output buffer. Supply your own to decode in an
+   * environment where the optional fflate import does not resolve — it must
+   * honour the `limit` argument (see `Inflate`).
+   */
+  inflate?: Inflate
+}
+
+// ── Frame format ──────────────────────────────────────────────────────
+
 /** Magic bytes to identify compressed payloads. */
 const COMPRESSED_MAGIC = new Uint8Array([0x52, 0x4a, 0x43]) // "RJC"
 const RAW_MAGIC = new Uint8Array([0x52, 0x4a, 0x52])        // "RJR"
 
 /**
  * Encode and optionally compress data for DA submission.
- * Prepends a 3-byte magic header so decode() knows whether to decompress.
+ *
+ * Frame layout:
+ * - raw:        `"RJR" ‖ data`
+ * - compressed: `"RJC" ‖ LEB128(data.length) ‖ deflate(data)`
+ *
+ * The compressed frame carries the *decompressed* length so that `decode()`
+ * can refuse an oversized payload before allocating for it, and so that the
+ * inflated result has an expected size to be checked against rather than
+ * being whatever the stream chose to produce.
  */
-export async function encode(data: Uint8Array): Promise<Uint8Array> {
-  const fflate = await getFflate()
+export async function encode(data: Uint8Array, opts: EncodeOptions = {}): Promise<Uint8Array> {
+  const deflate = opts.deflate ?? (await getFflate())?.deflateSync
 
-  if (fflate) {
-    const compressed = fflate.deflateSync(data)
-    // Only use compression if it actually saves space
-    if (compressed.length < data.length) {
-      const result = new Uint8Array(COMPRESSED_MAGIC.length + compressed.length)
+  if (deflate) {
+    const compressed = deflate(data)
+    const declaredLength = encodeBigInt(BigInt(data.length))
+    const framed = COMPRESSED_MAGIC.length + declaredLength.length + compressed.length
+
+    // Only use compression if the whole frame actually saves space — the
+    // length header counts, otherwise a barely-compressible payload gets
+    // bigger.
+    if (framed < RAW_MAGIC.length + data.length) {
+      const result = new Uint8Array(framed)
       result.set(COMPRESSED_MAGIC, 0)
-      result.set(compressed, COMPRESSED_MAGIC.length)
+      result.set(declaredLength, COMPRESSED_MAGIC.length)
+      result.set(compressed, COMPRESSED_MAGIC.length + declaredLength.length)
       return result
     }
   }
@@ -59,27 +207,123 @@ export async function encode(data: Uint8Array): Promise<Uint8Array> {
 /**
  * Decode data that was encoded with encode().
  * Detects the magic header and decompresses if needed.
+ *
+ * Never returns more than `maxDecompressedSize` bytes; anything larger is
+ * refused with `DASizeLimitError`. Every other rejection — a truncated
+ * frame, an unknown magic, a failure inside the decompressor — arrives as a
+ * `DADecodeError`.
  */
-export async function decode(data: Uint8Array): Promise<Uint8Array> {
-  if (data.length < 3) {
-    throw new Error('DA encoded data too short: missing magic header')
+export async function decode(data: Uint8Array, opts: DecodeOptions = {}): Promise<Uint8Array> {
+  const limit = opts.maxDecompressedSize ?? MAX_DECOMPRESSED_SIZE
+  if (!Number.isSafeInteger(limit) || limit < 0) {
+    throw new DADecodeError(`maxDecompressedSize must be a non-negative safe integer, got ${limit}`)
   }
 
-  const magic = data.slice(0, 3)
+  if (data.length < 3) {
+    throw new DADecodeError('DA encoded data too short: missing magic header')
+  }
+
+  const magic = data.subarray(0, 3)
 
   if (bytesEqual(magic, COMPRESSED_MAGIC)) {
-    const fflate = await getFflate()
-    if (!fflate) {
-      throw new Error('Data is compressed but fflate is not available')
-    }
-    return fflate.inflateSync(data.slice(3))
+    return decodeCompressed(data.subarray(3), limit, opts.inflate)
   }
 
   if (bytesEqual(magic, RAW_MAGIC)) {
-    return data.slice(3)
+    const body = data.subarray(3)
+    // Capped as well, so `decode` has one postcondition regardless of which
+    // branch it took. A caller that sized a buffer from the limit should not
+    // have to ask which frame it got.
+    if (body.length > limit) {
+      throw new DASizeLimitError(body.length, limit, 'raw payload')
+    }
+    return body.slice()
   }
 
-  throw new Error(`DA encoded data has unknown magic: ${Array.from(magic).map(b => b.toString(16)).join(' ')}`)
+  throw new DADecodeError(
+    `DA encoded data has unknown magic: ${Array.from(magic).map(b => b.toString(16)).join(' ')}`,
+  )
+}
+
+async function decodeCompressed(
+  frame: Uint8Array,
+  limit: number,
+  injected: Inflate | undefined,
+): Promise<Uint8Array> {
+  // ── 1. Read the declared decompressed length ──
+  const [declaredBig, lenSize] = decodeBigInt(frame, 0)
+  if (lenSize === 0 || lenSize >= frame.length) {
+    throw new DADecodeError('compressed frame is truncated: no length header or no body')
+  }
+  // ── 2. Refuse an oversized payload before inflating it ──
+  //
+  // This is the check that actually stops a zip bomb. It runs against the
+  // frame's own claim, costs one varint read, and allocates nothing: a blob
+  // that asks for a gigabyte is rejected while it is still a few kilobytes.
+  //
+  // Compared in bigint, so a declaration too large for a JS number is caught
+  // here rather than losing precision on the way to the comparison.
+  if (declaredBig > BigInt(limit)) {
+    throw new DASizeLimitError(Number(declaredBig), limit, 'declared decompressed size')
+  }
+  // Safe to narrow: `declaredBig` is at or below `limit`, a safe integer.
+  const declared = Number(declaredBig)
+
+  const body = frame.subarray(lenSize)
+
+  // ── 3. Inflate under a hard bound ──
+  //
+  // The bound is the declared size, which step 2 has already established is
+  // at or below the cap. A frame that declares 1 KiB and then streams 1 GiB
+  // is stopped by the inflater at 1 KiB — the declaration is not trusted, it
+  // is merely the tightest bound we can enforce cheaply.
+  const inflate = injected ?? (await defaultInflate())
+
+  let out: Uint8Array
+  try {
+    out = inflate(body, declared)
+  } catch (cause) {
+    throw new DADecodeError(
+      `decompression failed (declared ${declared} bytes, limit ${limit})`,
+      { cause },
+    )
+  }
+
+  // ── 4. Fail closed if the inflater ignored its bound ──
+  //
+  // Only reachable with an inflater that does not honour `limit`. By this
+  // point the memory has already been committed, so this cannot be the
+  // defence — it exists so that a bad inflater produces an error instead of
+  // silently oversized output.
+  if (out.length > limit) {
+    throw new DASizeLimitError(out.length, limit, 'decompressed payload')
+  }
+  if (out.length !== declared) {
+    throw new DADecodeError(
+      `decompressed payload is ${out.length} bytes, but the frame declared ${declared}`,
+    )
+  }
+
+  return out
+}
+
+/** fflate's `inflateSync`, bounded by a caller-supplied output buffer. */
+async function defaultInflate(): Promise<Inflate> {
+  const fflate = await getFflate()
+  if (!fflate) {
+    throw new DADecodeError(
+      'data is compressed but fflate is not available. ' +
+      'Install fflate, or pass DecodeOptions.inflate.',
+    )
+  }
+  return (body, expected) => {
+    // Sizing `out` at exactly the expected length is what makes this bounded:
+    // fflate refuses to grow a buffer the caller supplied, so a stream that
+    // wants to produce more throws here rather than allocating. It also means
+    // the returned length is unambiguous — we never have to guess whether
+    // fflate handed back a trimmed view or the padded buffer.
+    return fflate.inflateSync(body, { out: new Uint8Array(expected) })
+  }
 }
 
 /** Check whether two byte arrays are identical. */

--- a/packages/da/src/index.ts
+++ b/packages/da/src/index.ts
@@ -20,4 +20,6 @@ export { EthBlobDA } from './eth-blobs.js'
 export type { EthBlobDAOptions } from './eth-blobs.js'
 
 // Encoding
-export { encode, decode } from './encoding.js'
+export { encode, decode, MAX_DECOMPRESSED_SIZE } from './encoding.js'
+export { DADecodeError, DASizeLimitError } from './encoding.js'
+export type { EncodeOptions, DecodeOptions, Deflate, Inflate } from './encoding.js'

--- a/packages/da/test/encoding.test.ts
+++ b/packages/da/test/encoding.test.ts
@@ -1,7 +1,49 @@
 import { describe, it, expect } from 'vitest'
-import { encode, decode } from '../src/encoding.js'
+import { deflateRawSync, inflateRawSync } from 'node:zlib'
+import {
+  encode,
+  decode,
+  MAX_DECOMPRESSED_SIZE,
+  DADecodeError,
+  DASizeLimitError,
+  type Inflate,
+} from '../src/encoding.js'
 
 const encoder = new TextEncoder()
+
+/**
+ * A real raw-DEFLATE codec, so the compressed branch is exercised with
+ * genuine compressed data rather than a stand-in.
+ *
+ * fflate is an *optional* dependency and is not installed here, so without an
+ * injected codec `encode()` never compresses and `decode()` never reaches its
+ * inflate path — the entire compressed frame, including every size guard on
+ * it, would go untested. `DecodeOptions.inflate` is the seam that exists for
+ * exactly this: an environment where the optional fflate import does not
+ * resolve. fflate's `deflateSync`/`inflateSync` produce and consume raw
+ * DEFLATE, which is what `node:zlib`'s `*Raw` functions produce and consume,
+ * so this is the same wire format the shipped default would handle.
+ */
+const deflate = (data: Uint8Array): Uint8Array =>
+  new Uint8Array(deflateRawSync(Buffer.from(data.buffer, data.byteOffset, data.byteLength)))
+
+/**
+ * A *bounded* inflater, matching the contract `Inflate` documents: it refuses
+ * to produce more than `limit` bytes rather than inflating first and checking
+ * after. This is what the shipped fflate adapter does with its `out` buffer.
+ */
+const boundedInflate: Inflate = (data, limit) =>
+  new Uint8Array(
+    inflateRawSync(Buffer.from(data.buffer, data.byteOffset, data.byteLength), {
+      maxOutputLength: limit,
+    }),
+  )
+
+/** An inflater that ignores its bound — the shape of the original bug. */
+const unboundedInflate: Inflate = (data) =>
+  new Uint8Array(inflateRawSync(Buffer.from(data.buffer, data.byteOffset, data.byteLength)))
+
+const codec = { deflate, inflate: boundedInflate }
 
 describe('DA encoding', () => {
   it('roundtrips data through encode/decode', async () => {
@@ -40,5 +82,191 @@ describe('DA encoding', () => {
     const decoded = await decode(encoded)
 
     expect(decoded.length).toBe(0)
+  })
+
+  // ── Compressed frames ───────────────────────────────────────────────
+
+  describe('compressed frames', () => {
+    it('roundtrips a compressible payload through the compressed branch', async () => {
+      const data = new Uint8Array(64 * 1024).fill(0x41)
+      const encoded = await encode(data, codec)
+
+      // "RJC" — the compressed branch really was taken.
+      expect(Array.from(encoded.subarray(0, 3))).toEqual([0x52, 0x4a, 0x43])
+      expect(encoded.length).toBeLessThan(data.length)
+
+      const decoded = await decode(encoded, codec)
+      expect(decoded).toEqual(data)
+    })
+
+    it('falls back to a raw frame when compression would not save space', async () => {
+      // Random bytes do not compress; the frame must not grow.
+      const data = new Uint8Array(1024)
+      for (let i = 0; i < data.length; i++) data[i] = (i * 7919) % 256
+      const incompressible = new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', data))
+      const encoded = await encode(incompressible, codec)
+
+      expect(Array.from(encoded.subarray(0, 3))).toEqual([0x52, 0x4a, 0x52]) // "RJR"
+      expect(await decode(encoded, codec)).toEqual(incompressible)
+    })
+  })
+
+  // ── Decompression bomb ──────────────────────────────────────────────
+  //
+  // decode() runs on bytes that came off a DA layer, which is to say off the
+  // network from whoever chose to post them. DEFLATE reaches ~1000:1, so a
+  // few kilobytes can ask for gigabytes. See issue #24.
+  describe('decompression limits', () => {
+    /** 64 MiB of zeros — compresses to a few tens of KiB. A real bomb. */
+    function makeBomb(): { data: Uint8Array; uncompressedSize: number } {
+      const uncompressedSize = 64 * 1024 * 1024
+      const bomb = new Uint8Array(uncompressedSize)
+      const compressed = deflate(bomb)
+      // Sanity: this is only a bomb if it is genuinely tiny.
+      expect(compressed.length).toBeLessThan(uncompressedSize / 500)
+      return { data: bomb, uncompressedSize }
+    }
+
+    it('refuses a zip bomb without inflating it', async () => {
+      const { data, uncompressedSize } = makeBomb()
+      const encoded = await encode(data, { deflate })
+
+      expect(Array.from(encoded.subarray(0, 3))).toEqual([0x52, 0x4a, 0x43])
+      // The whole point: a payload that expands to 64 MiB travels as a
+      // handful of kilobytes.
+      expect(encoded.length).toBeLessThan(200 * 1024)
+
+      // The inflater must never be reached — refusing *after* inflating is
+      // not refusing, the memory is already gone by then.
+      let inflateCalls = 0
+      const counting: Inflate = (d, limit) => {
+        inflateCalls++
+        return boundedInflate(d, limit)
+      }
+
+      await expect(
+        decode(encoded, { inflate: counting, maxDecompressedSize: 1024 * 1024 }),
+      ).rejects.toThrow(DASizeLimitError)
+
+      expect(inflateCalls).toBe(0)
+
+      const err = await decode(encoded, { inflate: counting, maxDecompressedSize: 1024 * 1024 })
+        .catch((e: unknown) => e as DASizeLimitError)
+      expect(err).toBeInstanceOf(DASizeLimitError)
+      expect(err.limit).toBe(1024 * 1024)
+      expect(err.requested).toBe(uncompressedSize)
+    })
+
+    it('applies a 16 MiB default cap when none is configured', async () => {
+      expect(MAX_DECOMPRESSED_SIZE).toBe(16 * 1024 * 1024)
+
+      const { data } = makeBomb() // 64 MiB — over the default
+      const encoded = await encode(data, { deflate })
+
+      let inflateCalls = 0
+      const counting: Inflate = (d, limit) => {
+        inflateCalls++
+        return boundedInflate(d, limit)
+      }
+
+      // No maxDecompressedSize passed: the default has to be doing the work.
+      await expect(decode(encoded, { inflate: counting })).rejects.toThrow(DASizeLimitError)
+      expect(inflateCalls).toBe(0)
+    })
+
+    it('bounds the inflater when a frame lies about its decompressed size', async () => {
+      // Declare 1 KiB, then hand over a stream that expands to 8 MiB. The
+      // declaration passes the cheap check, so the inflater's bound is the
+      // only thing left standing between the frame and 8 MiB of memory.
+      const real = new Uint8Array(8 * 1024 * 1024)
+      const compressed = deflate(real)
+
+      const lengthHeader = new Uint8Array([0x80, 0x08]) // LEB128 for 1024
+      const encoded = new Uint8Array(3 + lengthHeader.length + compressed.length)
+      encoded.set([0x52, 0x4a, 0x43], 0)
+      encoded.set(lengthHeader, 3)
+      encoded.set(compressed, 3 + lengthHeader.length)
+
+      const limits: number[] = []
+      const recording: Inflate = (d, limit) => {
+        limits.push(limit)
+        return boundedInflate(d, limit)
+      }
+
+      await expect(decode(encoded, { inflate: recording })).rejects.toThrow(DADecodeError)
+      // The inflater was handed the declared size, not the 16 MiB cap — the
+      // tightest bound available, so the liar is stopped at 1 KiB.
+      expect(limits).toEqual([1024])
+    })
+
+    it('fails closed when the inflater ignores its bound', async () => {
+      // The original bug, preserved as an inflater: inflate everything, ask
+      // questions later. The post-inflation check cannot save the memory, but
+      // it must not let oversized output through as if it were fine.
+      const real = new Uint8Array(4 * 1024 * 1024).fill(0x5a)
+      const compressed = deflate(real)
+
+      const lengthHeader = new Uint8Array([0x80, 0x08]) // LEB128 for 1024
+      const encoded = new Uint8Array(3 + lengthHeader.length + compressed.length)
+      encoded.set([0x52, 0x4a, 0x43], 0)
+      encoded.set(lengthHeader, 3)
+      encoded.set(compressed, 3 + lengthHeader.length)
+
+      await expect(decode(encoded, { inflate: unboundedInflate })).rejects.toThrow(DADecodeError)
+    })
+
+    it('honours a custom maxDecompressedSize', async () => {
+      const data = new Uint8Array(64 * 1024).fill(0x41)
+      const encoded = await encode(data, codec)
+
+      // Just under the payload's size — refused.
+      await expect(
+        decode(encoded, { ...codec, maxDecompressedSize: 64 * 1024 - 1 }),
+      ).rejects.toThrow(DASizeLimitError)
+
+      // Exactly the payload's size — allowed. The cap is inclusive.
+      expect(await decode(encoded, { ...codec, maxDecompressedSize: 64 * 1024 })).toEqual(data)
+    })
+
+    it('caps a raw frame too, so decode has one size postcondition', async () => {
+      const data = new Uint8Array(4096).fill(0x11)
+      const encoded = await encode(data) // no deflate available → raw frame
+      expect(Array.from(encoded.subarray(0, 3))).toEqual([0x52, 0x4a, 0x52])
+
+      await expect(decode(encoded, { maxDecompressedSize: 4095 })).rejects.toThrow(DASizeLimitError)
+      expect(await decode(encoded, { maxDecompressedSize: 4096 })).toEqual(data)
+    })
+
+    it('reports a refusal as a typed error, not whatever zlib threw', async () => {
+      const real = new Uint8Array(2 * 1024 * 1024)
+      const compressed = deflate(real)
+      const lengthHeader = new Uint8Array([0x80, 0x08]) // LEB128 for 1024
+      const encoded = new Uint8Array(3 + lengthHeader.length + compressed.length)
+      encoded.set([0x52, 0x4a, 0x43], 0)
+      encoded.set(lengthHeader, 3)
+      encoded.set(compressed, 3 + lengthHeader.length)
+
+      const err = await decode(encoded, { inflate: boundedInflate }).catch((e: unknown) => e)
+
+      // A caller catching DADecodeError should not also have to know about
+      // ERR_BUFFER_TOO_LARGE, or about which compression library is in use.
+      expect(err).toBeInstanceOf(DADecodeError)
+      expect((err as Error).name).toBe('DADecodeError')
+      // ...but the original failure is still reachable for debugging.
+      expect((err as { cause?: unknown }).cause).toBeInstanceOf(Error)
+    })
+
+    it('rejects a truncated compressed frame', async () => {
+      // "RJC" and nothing else — no length header, no body.
+      await expect(decode(new Uint8Array([0x52, 0x4a, 0x43]))).rejects.toThrow(DADecodeError)
+      // A length header but no body.
+      await expect(decode(new Uint8Array([0x52, 0x4a, 0x43, 0x10]))).rejects.toThrow(/truncated/)
+    })
+
+    it('rejects a nonsensical maxDecompressedSize', async () => {
+      const encoded = await encode(encoder.encode('hi'))
+      await expect(decode(encoded, { maxDecompressedSize: -1 })).rejects.toThrow(DADecodeError)
+      await expect(decode(encoded, { maxDecompressedSize: 1.5 })).rejects.toThrow(DADecodeError)
+    })
   })
 })

--- a/packages/mempool/README.md
+++ b/packages/mempool/README.md
@@ -17,7 +17,7 @@ npm install @johnhenry/raijin-mempool
 1. **It collides with the state machine's convention.** `@johnhenry/raijin-core`'s `StateMachine` treats `tx.data[0]` as the transaction *type*. A `data` layout can't serve both defaults at once — if your transactions carry typed data, supply your own `FeeExtractor` (e.g. `(tx) => tx.value` for tip-style fees).
 2. **The config doc-comment in older builds says the default is `tx.value`. It is not.** The default is the 8-byte data prefix; verify with `defaultFeeExtractor(tx)` if in doubt.
 
-Also note: this package is standalone. `@johnhenry/raijin-validator` ships its **own, different `Mempool`** (FIFO, no verification, throws when full) and uses that one internally — see "Which mempool am I holding?" below.
+This pool *is* the one `@johnhenry/raijin-validator` runs. It used to ship a second, simpler class of the same name; it no longer does, and `Mempool` imported from either package is now this implementation — see "Which mempool am I holding?" below.
 
 ## Quick start
 
@@ -85,15 +85,16 @@ pool.removeBatch(block.transactions)               // prune by sender+nonce
 
 ## Which mempool am I holding?
 
-| | `@johnhenry/raijin-mempool` `Mempool` | `@johnhenry/raijin-validator` `Mempool` |
-| --- | --- | --- |
-| Ordering | fee-descending | FIFO |
-| Signature check | yes, injected verifier | none |
-| Full pool | evict lowest / reject | `throw new Error('Mempool full')` |
-| Submit API | `submit(tx) → boolean` | `add(tx) → tx-hash hex` |
-| Used by `ValidatorNode` | no | yes |
+One implementation, two import paths. `@johnhenry/raijin-validator` re-exports this class:
 
-They share a name and nothing else. If you want fee ordering inside a validator today, you wire it yourself (the fee-ordered pool is not yet integrated into `ValidatorNode`).
+```js
+import { Mempool } from '@johnhenry/raijin-mempool'   // same class
+import { Mempool } from '@johnhenry/raijin-validator' // as this one
+```
+
+This was not always true, and older documentation says so: `raijin-validator` used to define its own FIFO `Mempool` with no signature verification that threw when full, and `ValidatorNode` used that one. It doesn't exist any more. `ValidatorNode` now constructs *this* pool, with `maxSize: maxMempoolSize` and a verifier built from the node's `identity.verify` — the same `SignatureVerifier` the state machine uses — so a transaction with a bad signature is rejected at `submitTransaction()` rather than becoming a revert receipt one block later.
+
+Fee ordering is therefore active inside a validator by default. The one thing to watch is the fee convention above: `defaultFeeExtractor` reads `tx.data`'s first 8 bytes, which collide with the state machine's type byte, so supply your own `FeeExtractor` if your transactions carry typed data.
 
 ## Provenance
 

--- a/packages/mempool/package.json
+++ b/packages/mempool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-mempool",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Transaction mempool with fee-based ordering for the Raijin mesh rollup",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1"
   },
   "devDependencies": {
     "typescript": "^5.7",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -13,9 +13,10 @@ npm install @johnhenry/raijin-sdk
 ## Things to know first
 
 - **`Wallet` needs Web Crypto Ed25519.** Node 20+ and current browsers have it; older environments throw at `Wallet.generate()`. The repo targets Node ≥ 24.
-- **Signatures cover `encodeTx(tx)` — everything except the signature itself.** Mutate any field after `buildTx()` and verification fails (that's the point). Validators hash the same bytes for the receipt `txHash`, so `hash(encodeTx(tx))` is how you match your transaction to its receipt.
+- **Signatures cover `encodeTx(tx)` — everything except the signature itself.** Mutate any field after `buildTx()` and verification fails (that's the point).
+- **A receipt's `txHash` is `hash(encodeTxSigned(tx))`, not `hash(encodeTx(tx))`.** The canonical transaction identifier includes the signature, and it is the same value everywhere: receipt `txHash`, block `txRoot` leaves, and the mempool's dedup key. Signature *verification* still runs over the unsigned `encodeTx(tx)` bytes, because that is what was signed — the two encodings have different jobs, and only the signed one identifies a transaction. See "Correlating submissions with receipts" below.
 - **Nonce management is yours.** `buildTx()` takes an explicit `nonce`; fetch the account first (`(await client.getAccount(wallet.publicKey)).nonce`) or track it locally. A wrong nonce becomes a `revert` receipt, not an error at submit time.
-- **`chainId` defaults to `1n`** and exists to prevent cross-chain replay; the reference state machine does not yet enforce it.
+- **`chainId` is required — there is no default.** It exists to prevent cross-chain replay, and a default would hand every deployment that never chose one the same id. It is part of the signed bytes; the reference state machine does not additionally check it against a configured chain.
 
 ## Quick start
 
@@ -47,7 +48,7 @@ A complete end-to-end run — real Ed25519 verification against an in-process `V
 | Member | Purpose |
 | --- | --- |
 | `static generate(opts?): Promise<Wallet>` | New Ed25519 keypair via `crypto.subtle.generateKey`. **Non-extractable by default** — pass `{ extractable: true }` only if the key has to be exported. |
-| `static fromKey(pkcs8: Uint8Array): Promise<Wallet>` | Import a private key (PKCS8); the public key is derived from it. |
+| `static fromKey(pkcs8, opts?): Promise<Wallet>` | Import a private key (PKCS8); the public key is derived from it. **Non-extractable by default**, same as `generate()` — pass `{ extractable: true }` only if the key has to be exported again. |
 | `publicKey: Uint8Array` | 32-byte raw public key — this is your address. |
 | `sign(message): Promise<Uint8Array>` | Raw Ed25519 signature (64 bytes, deterministic). |
 | `buildTx(opts: BuildTxOptions): Promise<Transaction>` | Assembles `{ from: publicKey, to, value, nonce, data?, chainId }` and signs it. |
@@ -56,7 +57,7 @@ A complete end-to-end run — real Ed25519 verification against an in-process `V
 `BuildTxOptions`: `{ to, value, nonce, data?, chainId }` — `data` defaults to empty (which the state machine treats as a `Transfer`; set `data[0]` to a `TransactionType` byte for anything else).
 
 - **`chainId` is required.** It is the only field separating one deployment from another, so a default would give every chain that never chose one the same id, and a signed transfer on either would be a valid signed transfer on the other for any account whose key is shared between them.
-- **Private keys are non-extractable unless you ask.** In a browser that is the strongest guarantee WebCrypto offers: the key cannot leave the browser, whatever script asks for it. `exportPrivateKey()` needs `Wallet.generate({ extractable: true })`.
+- **Private keys are non-extractable unless you ask** — on `generate()` **and** on `fromKey()`. In a browser that is the strongest guarantee WebCrypto offers: the key cannot leave the browser, whatever script asks for it. `fromKey` matters most here, because it is the persistence path — where a key written to storage comes back — so it is the path most likely to be handed to code that never asked for an exportable key. `exportPrivateKey()` needs `{ extractable: true }` at whichever of the two created the wallet.
 
 ### `RaijinClient`
 
@@ -82,16 +83,16 @@ interface ClientTransport {
 }
 ```
 
-For tests and demos, back it directly with a `ValidatorNode`: `getAccount` → `node.stateMachine.getAccount`, `submitTransaction` → `node.submitTransaction` + match the receipt by `hash(encodeTx(tx))` in `onBlockFinalized`.
+For tests and demos, back it directly with a `ValidatorNode`: `getAccount` → `node.stateMachine.getAccount`, `submitTransaction` → `node.submitTransaction` + match the receipt by `hash(encodeTxSigned(tx))` in `onBlockFinalized`.
 
 ## Correlating submissions with receipts
 
-Receipts identify transactions by `txHash = hash(encodeTx(tx))` — the hash of the *unsigned* canonical encoding (the validator's mempool separately keys by the signed encoding; don't mix them up). To match your own submission inside a block-finalized callback:
+Receipts identify transactions by `txHash = hash(encodeTxSigned(tx))` — the hash of the *signed* canonical encoding. It is the same identifier the block's `txRoot` leaves and the mempool's dedup key use, so there is one transaction id, not two. (`node.submitTransaction(tx)` returns that same hash as hex.) To match your own submission inside a block-finalized callback:
 
 ```js
-import { hash, encodeTx, equal } from '@johnhenry/raijin-core'
+import { hash, encodeTxSigned, equal } from '@johnhenry/raijin-core'
 
-const want = await hash(encodeTx(tx))
+const want = await hash(encodeTxSigned(tx))
 node.onBlockFinalized((_block, receipts) => {
   const mine = receipts.find((r) => equal(r.txHash, want))
   if (mine) console.log(mine.status, mine.revertReason ?? '')

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-sdk",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Developer-facing client API for the Raijin mesh rollup",
   "repository": {
     "type": "git",
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1"
   },
   "devDependencies": {
     "typescript": "^5.7",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,4 +8,4 @@ export { RaijinClient } from './client.js'
 export type { ClientTransport } from './client.js'
 
 export { Wallet } from './wallet.js'
-export type { BuildTxOptions } from './wallet.js'
+export type { BuildTxOptions, GenerateOptions, ImportOptions } from './wallet.js'

--- a/packages/sdk/src/wallet.ts
+++ b/packages/sdk/src/wallet.ts
@@ -39,6 +39,25 @@ export interface GenerateOptions {
   extractable?: boolean
 }
 
+export interface ImportOptions {
+  /**
+   * Whether the imported private key can be exported again with
+   * `exportPrivateKey()`. Default: `false`, the same default `generate()`
+   * uses.
+   *
+   * `fromKey` is the *persistence* path — it is where a key that was written
+   * to storage comes back — so it is the path most likely to be handed to
+   * code that never asked for an exportable key. Importing extractable by
+   * default meant every restored wallet could be re-exported by anything
+   * running in the origin, which quietly undid the non-extractable default on
+   * `generate()` for exactly the keys that live longest.
+   *
+   * Pass `{ extractable: true }` only where the call site genuinely needs to
+   * hand the key back out again (re-encrypting a backup, migrating a store).
+   */
+  extractable?: boolean
+}
+
 export class Wallet implements TransactionSigner {
   #privateKey: CryptoKey
   #publicKeyBytes: Uint8Array
@@ -67,9 +86,26 @@ export class Wallet implements TransactionSigner {
     return new Wallet(privateKey, publicKeyBytes)
   }
 
-  /** Import an existing Ed25519 private key (PKCS8 format). */
-  static async fromKey(pkcs8: Uint8Array): Promise<Wallet> {
-    const privateKey = await globalThis.crypto.subtle.importKey(
+  /**
+   * Import an existing Ed25519 private key (PKCS8 format). The imported key
+   * is **non-extractable** unless `{ extractable: true }` is passed — see
+   * `ImportOptions`.
+   */
+  static async fromKey(pkcs8: Uint8Array, opts: ImportOptions = {}): Promise<Wallet> {
+    const extractable = opts.extractable ?? false
+
+    // WebCrypto will only give up the public half of an Ed25519 private key
+    // through a JWK export, and a non-extractable key refuses to export at
+    // all — so the public key has to be derived from an extractable import
+    // whatever the caller asked for.
+    //
+    // Derive it from a throwaway, then import the *signing* key separately
+    // with the requested extractability. The throwaway never leaves this
+    // function and never reaches the returned Wallet, and it discloses
+    // nothing the caller does not already have: they handed us the PKCS8
+    // bytes. What it buys is that the long-lived key the Wallet holds — the
+    // one other code can reach — carries the caller's choice, not `true`.
+    const derivable = await globalThis.crypto.subtle.importKey(
       'pkcs8',
       // Pass the view, not `.buffer` — a Uint8Array that is a window into a
       // larger ArrayBuffer would otherwise import the whole buffer.
@@ -79,11 +115,24 @@ export class Wallet implements TransactionSigner {
       ['sign'],
     )
 
-    // Derive public key: export as JWK, import as public key, export raw
-    const jwk = await globalThis.crypto.subtle.exportKey('jwk', privateKey)
-    // Ed25519 JWK has 'x' as the public key component
-    const publicKeyB64 = jwk.x!
+    // Derive public key: export as JWK; Ed25519 JWK carries the public key
+    // component in 'x'.
+    const jwk = await globalThis.crypto.subtle.exportKey('jwk', derivable)
+    const publicKeyB64 = jwk.x
+    if (typeof publicKeyB64 !== 'string') {
+      throw new Error('Wallet.fromKey: imported key has no public key component (jwk.x)')
+    }
     const publicKeyBytes = base64urlDecode(publicKeyB64)
+
+    const privateKey = extractable
+      ? derivable
+      : await globalThis.crypto.subtle.importKey(
+          'pkcs8',
+          pkcs8 as BufferSource,
+          'Ed25519',
+          false,
+          ['sign'],
+        )
 
     return new Wallet(privateKey, publicKeyBytes)
   }
@@ -140,7 +189,8 @@ export class Wallet implements TransactionSigner {
     if (!this.#privateKey.extractable) {
       throw new Error(
         'Wallet.exportPrivateKey: this key is non-extractable. ' +
-        'Pass Wallet.generate({ extractable: true }) if the key has to leave the process.',
+        'Pass { extractable: true } to Wallet.generate() or Wallet.fromKey() ' +
+        'if the key has to leave the process.',
       )
     }
     const pkcs8 = await globalThis.crypto.subtle.exportKey('pkcs8', this.#privateKey)

--- a/packages/sdk/test/wallet.test.ts
+++ b/packages/sdk/test/wallet.test.ts
@@ -143,6 +143,38 @@ describe('Wallet', () => {
       expect(sig.length).toBe(64)
     })
 
+    // `fromKey` is the persistence path — the one a key comes *back* through
+    // — and it hardcoded `extractable: true`, so every restored wallet could
+    // be re-exported by anything in the origin. See issue #23.
+    it('imports a non-extractable private key by default', async () => {
+      const source = await Wallet.generate({ extractable: true })
+      const pkcs8 = await source.exportPrivateKey()
+
+      const restored = await Wallet.fromKey(pkcs8)
+      await expect(restored.exportPrivateKey()).rejects.toThrow(/non-extractable/)
+    })
+
+    it('imports an extractable key only when the call site asks', async () => {
+      const source = await Wallet.generate({ extractable: true })
+      const pkcs8 = await source.exportPrivateKey()
+
+      const restored = await Wallet.fromKey(pkcs8, { extractable: true })
+      const reexported = await restored.exportPrivateKey()
+      expect(reexported).toEqual(pkcs8)
+    })
+
+    it('a default-imported wallet still signs, and signs identically', async () => {
+      const source = await Wallet.generate({ extractable: true })
+      const pkcs8 = await source.exportPrivateKey()
+      const restored = await Wallet.fromKey(pkcs8)
+
+      // Non-extractable costs nothing at the point of use: same public key,
+      // same signatures. Only `exportPrivateKey` is closed off.
+      expect(restored.publicKey).toEqual(source.publicKey)
+      const msg = new Uint8Array([9, 8, 7])
+      expect(await restored.sign(msg)).toEqual(await source.sign(msg))
+    })
+
     it('refuses to build a transaction with no chainId', async () => {
       const wallet = await Wallet.generate()
       await expect(

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -8,9 +8,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0",
-    "@johnhenry/raijin-consensus": "^0.0.0",
-    "@johnhenry/raijin-validator": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1",
+    "@johnhenry/raijin-consensus": "^0.0.1",
+    "@johnhenry/raijin-validator": "^0.0.1"
   },
   "devDependencies": {
     "vitest": "^3",

--- a/packages/test-harness/src/index.ts
+++ b/packages/test-harness/src/index.ts
@@ -9,9 +9,12 @@ export type { Checker, CheckResult } from './orchestrator.js'
 // Node
 export { RaijinTestNode } from './nodes/raijin-test-node.js'
 export type { RaijinTestNodeConfig } from './nodes/raijin-test-node.js'
+export { ByzantineTestNode } from './nodes/byzantine-node.js'
+export type { ByzantineTestNodeConfig } from './nodes/byzantine-node.js'
 
 // Network
 export { PartitionableNetwork } from './network/partitionable-network.js'
+export type { DeliveryOrder, DeliveryRecord } from './network/partitionable-network.js'
 export { SeededPRNG } from './network/seeded-prng.js'
 
 // Checkers
@@ -41,4 +44,5 @@ export {
   mockSign,
   mockVerifier,
   makeTestKey,
+  ByzantinePeer,
 } from '../../consensus/test/helpers.js'

--- a/packages/test-harness/src/network/partitionable-network.ts
+++ b/packages/test-harness/src/network/partitionable-network.ts
@@ -11,6 +11,16 @@ import { SeededPRNG } from './seeded-prng.js'
 
 type Handler = (from: Uint8Array, msg: ConsensusMessage) => Promise<void> | void
 
+/** How `PartitionableNetwork.deliver()` chooses among ready messages. */
+export type DeliveryOrder = 'fifo' | 'random'
+
+/** One delivered message, as recorded in `PartitionableNetwork.deliveryLog`. */
+export interface DeliveryRecord {
+  from: string
+  to: string
+  type: ConsensusMessage['type']
+}
+
 interface QueueItem {
   from: Uint8Array
   fromHex: string
@@ -50,10 +60,44 @@ export class PartitionableNetwork {
   #dropRates = new Map<string, number>() // "fromHex:toHex" → probability [0,1)
   #prng: SeededPRNG | null = null
   #now = 0  // logical time for delays
+  #deliveryOrder: DeliveryOrder = 'fifo'
+  #deliveryLog: DeliveryRecord[] = []
 
-  /** Set the PRNG for probabilistic message drops */
+  /** Set the PRNG for probabilistic message drops and seeded reordering. */
   setPRNG(prng: SeededPRNG): void {
     this.#prng = prng
+  }
+
+  /**
+   * How `deliver()` picks among the messages that are ready to be delivered.
+   *
+   * `'fifo'` (the default, and the only behaviour this network had) always
+   * takes the oldest deliverable message. That makes every run identical, but
+   * it also means the suite only ever exercises ONE interleaving — and a
+   * consensus protocol's interesting failures live in the interleavings. A
+   * crash test passes under FIFO and says nothing about the other orderings.
+   *
+   * `'random'` picks uniformly among the currently-deliverable messages using
+   * the seeded PRNG, so a seed names an interleaving and a failing seed
+   * reproduces exactly. It requires `setPRNG` — without one it silently stays
+   * FIFO, which would be a lie, so it throws instead.
+   */
+  setDeliveryOrder(order: DeliveryOrder): void {
+    if (order === 'random' && !this.#prng) {
+      throw new Error('setDeliveryOrder("random") requires setPRNG() first')
+    }
+    this.#deliveryOrder = order
+  }
+
+  /**
+   * Every message delivered so far, in the order it was delivered.
+   *
+   * This is what makes "the same seed reproduces the same run" a checkable
+   * claim rather than an assurance: two runs of the same scenario under the
+   * same seed must produce identical logs, and two different seeds must not.
+   */
+  get deliveryLog(): readonly DeliveryRecord[] {
+    return this.#deliveryLog
   }
 
   /** Create a transport for a peer */
@@ -106,21 +150,53 @@ export class PartitionableNetwork {
 
   /** Deliver one queued message (if any is ready) */
   async deliver(): Promise<boolean> {
-    // Find first deliverable message (not blocked, not delayed, not disconnected)
+    // Collect what could be delivered right now (not blocked, not still
+    // delayed, recipient not disconnected). Under 'fifo' that is just the
+    // oldest such message. Under 'random' it is the oldest message *per
+    // link*, and the PRNG picks among those.
+    //
+    // Per-link order is preserved on purpose. Every transport raijin is meant
+    // to run on — an ordered WebRTC DataChannel, a WebSocket — delivers one
+    // peer's messages to one peer in the order they were sent; what a real
+    // network reorders is messages travelling on DIFFERENT links. Shuffling
+    // within a link would model a transport nobody deploys, and it would
+    // reorder a sender's own PRE-PREPARE behind its own PREPARE, which no
+    // sender can do.
+    const ready: number[] = []
+    const seenLinks = new Set<string>()
     for (let i = 0; i < this.#queue.length; i++) {
       const item = this.#queue[i]
       if (item.deliverAfter > this.#now) continue
       if (this.#blocked.has(`${item.fromHex}:${item.to}`)) continue
       if (this.#disconnected.has(item.to)) continue
-
-      this.#queue.splice(i, 1)
-      const handler = this.#peers.get(item.to)
-      if (handler) {
-        await handler(item.from, item.msg)
+      if (this.#deliveryOrder === 'fifo') {
+        ready.push(i)
+        break
       }
-      return true
+      const link = `${item.fromHex}:${item.to}`
+      if (seenLinks.has(link)) continue // keep this link's own order
+      seenLinks.add(link)
+      ready.push(i)
     }
-    return false
+    if (ready.length === 0) return false
+
+    const chosen =
+      this.#deliveryOrder === 'random' && this.#prng
+        ? ready[this.#prng.nextInt(ready.length)]
+        : ready[0]
+
+    const [item] = this.#queue.splice(chosen, 1)
+    this.#deliveryLog.push({
+      from: item.fromHex,
+      to: item.to,
+      type: item.msg.type,
+    })
+
+    const handler = this.#peers.get(item.to)
+    if (handler) {
+      await handler(item.from, item.msg)
+    }
+    return true
   }
 
   /** Deliver all ready messages */

--- a/packages/test-harness/src/nodes/byzantine-node.ts
+++ b/packages/test-harness/src/nodes/byzantine-node.ts
@@ -1,0 +1,107 @@
+/**
+ * ByzantineTestNode — a validator in the cluster that lies.
+ *
+ * Everything else this harness can do to a node makes it *stop*: crash it,
+ * partition it, drop its messages, delay them. Those are crash faults, and
+ * they are the half of the fault model that does not need Byzantine fault
+ * tolerance to survive. A Byzantine node keeps sending. It is a member of the
+ * validator set, it holds a real key, and every message it emits is correctly
+ * formed and correctly signed — the lie is in *what* it says and *who it says
+ * it to*, which is the only thing signatures cannot fix.
+ *
+ * This is deliberately not a `RaijinTestNode`: it has no ValidatorNode, no
+ * mempool, no state machine and no block producer, because an honest
+ * implementation cannot be talked into equivocating. It is a transport, a
+ * key, and the ability to address peers one at a time.
+ *
+ * The protocol-level primitives live on `ByzantinePeer`
+ * (packages/consensus/test/helpers.ts), shared with the consensus unit tests
+ * so there is one definition of "how a liar speaks PBFT". This class is the
+ * cluster-level wrapper: it knows its orchestrator id and which peers exist.
+ */
+
+import type { Block } from '@johnhenry/raijin-core'
+import type { NetworkTransport } from '@johnhenry/raijin-consensus'
+// NOTE: from the consensus SOURCE, not from '@johnhenry/raijin-consensus'.
+// That specifier resolves to the package's built `dist`, which is only as
+// fresh as the last build — and `ByzantinePeer` (consensus/test/helpers.ts)
+// already builds its vote payloads against the source. Two ValidatorSet
+// classes from two builds would silently disagree about `epoch()`, and a
+// disagreement about the epoch is an invalid signature, not a failing
+// assertion. One source, one epoch.
+import { ValidatorSet } from '../../../consensus/src/validator-set.js'
+import { ByzantinePeer } from '../../../consensus/test/helpers.js'
+
+export interface ByzantineTestNodeConfig {
+  /** Unique string ID for this node (for orchestrator bookkeeping). */
+  id: string
+  /** 32-byte public key for this validator. */
+  publicKey: Uint8Array
+  /** This node's own transport. */
+  transport: NetworkTransport
+  /**
+   * The deployment this node votes in. Vote signatures cover it, so a liar
+   * that names the wrong chain produces signatures nobody accepts — which
+   * tests nothing.
+   */
+  chainId: bigint
+  /**
+   * The validator set this node votes under; its `epoch()` is inside every
+   * signed payload, for the same reason.
+   */
+  validators: ValidatorSet
+  /**
+   * Factory for a transport that reports an arbitrary sender id. Models a
+   * transport that does not authenticate its peers — a relay, a gossip hub,
+   * a signalling server forwarding a self-declared id. Needed for replay
+   * attacks; see `ByzantinePeer`'s `spoof` option.
+   */
+  spoof?: (identity: Uint8Array) => NetworkTransport
+}
+
+export class ByzantineTestNode {
+  readonly id: string
+  readonly publicKey: Uint8Array
+  readonly peer: ByzantinePeer
+
+  constructor(config: ByzantineTestNodeConfig) {
+    this.id = config.id
+    this.publicKey = config.publicKey
+    this.peer = new ByzantinePeer(config.publicKey, config.transport, {
+      chainId: config.chainId,
+      validators: config.validators,
+      listen: true,
+      spoof: config.spoof,
+    })
+  }
+
+  /**
+   * A Byzantine node never stops — that is what makes it Byzantine rather
+   * than crashed. Present so it can sit alongside `RaijinTestNode` in
+   * bookkeeping without special-casing.
+   */
+  get running(): boolean {
+    return true
+  }
+
+  /**
+   * Propose two different blocks at the same view and sequence to two
+   * disjoint groups of peers, each backed by this node's own PREPARE (and,
+   * by default, its COMMIT) so that each group sees a self-consistent round.
+   *
+   * Returns the consensus digest of each group's block, in order.
+   */
+  async equivocate(opts: {
+    view: bigint
+    sequence: bigint
+    groups: Array<{ targets: Uint8Array[]; block: Block }>
+    commit?: boolean
+  }): Promise<Uint8Array[]> {
+    return this.peer.equivocate(opts)
+  }
+
+  /** Everything this node overheard, in delivery order. */
+  get received(): ReadonlyArray<{ from: Uint8Array; msg: unknown }> {
+    return this.peer.received
+  }
+}

--- a/packages/test-harness/src/nodes/raijin-test-node.ts
+++ b/packages/test-harness/src/nodes/raijin-test-node.ts
@@ -52,6 +52,7 @@ export class RaijinTestNode {
     this.store = new InMemoryStateStore()
 
     this.node = new ValidatorNode({
+      chainId: 1n,
       identity: {
         publicKey: config.publicKey,
         sign: config.sign,

--- a/packages/test-harness/src/nodes/raijin-test-node.ts
+++ b/packages/test-harness/src/nodes/raijin-test-node.ts
@@ -5,6 +5,7 @@
 import {
   InMemoryStateStore,
   TransactionType,
+  accountKey,
   encodeAccount,
   encodeTx,
   toHex,
@@ -16,7 +17,6 @@ import type { ConsensusTimer, NetworkTransport } from '@johnhenry/raijin-consens
 import { ValidatorNode } from '@johnhenry/raijin-validator'
 import { mockSign } from '../../../consensus/test/helpers.js'
 
-const encoder = new TextEncoder()
 
 export interface RaijinTestNodeConfig {
   /** Unique string ID for this node (for orchestrator bookkeeping). */
@@ -111,11 +111,7 @@ export class RaijinTestNode {
   async fund(account: Uint8Array, amount: bigint): Promise<void> {
     // Read existing account to preserve nonce/reputation, then add to balance
     const existing = await this.node.stateMachine.getAccount(account)
-    const prefix = encoder.encode('account:')
-    const key = new Uint8Array(prefix.length + account.length)
-    key.set(prefix, 0)
-    key.set(account, prefix.length)
-    await this.store.put(key, encodeAccount({
+    await this.store.put(accountKey(account), encodeAccount({
       balance: existing.balance + amount,
       nonce: existing.nonce,
       reputation: existing.reputation,

--- a/packages/test-harness/src/orchestrator.ts
+++ b/packages/test-harness/src/orchestrator.ts
@@ -7,6 +7,14 @@
  */
 
 import { toHex } from '@johnhenry/raijin-core'
+// NOTE: from the consensus SOURCE, not from '@johnhenry/raijin-consensus'.
+// That specifier resolves to the package's built `dist`, which is only as
+// fresh as the last build — and `ByzantinePeer` (consensus/test/helpers.ts)
+// already builds its vote payloads against the source. Two ValidatorSet
+// classes from two builds would silently disagree about `epoch()`, and a
+// disagreement about the epoch is an invalid signature, not a failing
+// assertion. One source, one epoch.
+import { ValidatorSet } from '../../consensus/src/validator-set.js'
 import {
   MockTimer,
   mockSign,
@@ -16,8 +24,17 @@ import {
 import { PartitionableNetwork } from './network/partitionable-network.js'
 import { SeededPRNG } from './network/seeded-prng.js'
 import { RaijinTestNode } from './nodes/raijin-test-node.js'
+import { ByzantineTestNode } from './nodes/byzantine-node.js'
 import { EventCollector } from './timeline/event-collector.js'
 import { ReportGenerator, type ReportEntry } from './timeline/report-generator.js'
+
+/**
+ * The chain id every node in an orchestrated cluster votes under.
+ *
+ * Matches the one `RaijinTestNode` gives its `ValidatorNode`; a Byzantine
+ * node has to name the same chain as the nodes it lies to.
+ */
+const CHAIN_ID = 1n
 
 export interface Checker {
   name: string
@@ -33,22 +50,39 @@ export interface CheckResult {
 export class TestOrchestrator {
   readonly network: PartitionableNetwork
   readonly timer: MockTimer
+  /** Honest nodes only. Checkers run over these — a liar's view of the chain
+   *  is not evidence of anything. */
   readonly nodes = new Map<string, RaijinTestNode>()
+  /** Byzantine members of the validator set. See `addByzantineNode`. */
+  readonly byzantine = new Map<string, ByzantineTestNode>()
   readonly events = new EventCollector()
 
   #validators: Uint8Array[] = []
   #nextIndex = 1
   #nodeKeys = new Map<string, Uint8Array>()
   #pendingNodes: string[] = []
+  #pendingByzantine: string[] = []
   #built = false
   #nonces = new Map<string, bigint>()  // hex(from) → next nonce
+  #seed: number | null = null
 
   constructor(opts?: { seed?: number }) {
     this.network = new PartitionableNetwork()
     this.timer = new MockTimer()
     if (opts?.seed !== undefined) {
+      this.#seed = opts.seed
       this.network.setPRNG(new SeededPRNG(opts.seed))
     }
+  }
+
+  /**
+   * The seed this cluster was built with, or null if none was given.
+   *
+   * A seeded run is only reproducible if the seed is recoverable from a
+   * failure, so tests that sweep seeds should print this one.
+   */
+  get seed(): number | null {
+    return this.#seed
   }
 
   /**
@@ -63,6 +97,28 @@ export class TestOrchestrator {
     this.#nodeKeys.set(id, key)
     this.#pendingNodes.push(id)
     this.events.record(id, 'lifecycle', 'node-registered', { index })
+  }
+
+  /**
+   * Register a validator that will LIE rather than crash.
+   *
+   * It joins the validator set exactly like an honest node — so it counts
+   * toward `n`, it takes its turn as leader, and honest peers accept its
+   * signatures — but no `ValidatorNode` is built for it. It is a transport
+   * and a key (see `ByzantineTestNode`), which is the only way to get
+   * behaviour an honest implementation would refuse to produce.
+   *
+   * Leader rotation is round-robin over registration order, so registering
+   * the liar first makes it the leader for view 0.
+   */
+  addByzantineNode(id: string): void {
+    if (this.#built) throw new Error('Cannot add nodes after startAll()')
+    const index = this.#nextIndex++
+    const key = makeTestKey(index)
+    this.#validators.push(key)
+    this.#nodeKeys.set(id, key)
+    this.#pendingByzantine.push(id)
+    this.events.record(id, 'lifecycle', 'byzantine-node-registered', { index })
   }
 
   /**
@@ -88,6 +144,24 @@ export class TestOrchestrator {
         this.events.record(id, 'lifecycle', 'node-added', {})
       }
       this.#pendingNodes = []
+
+      for (const id of this.#pendingByzantine) {
+        const key = this.#nodeKeys.get(id)!
+        const node = new ByzantineTestNode({
+          id,
+          publicKey: key,
+          chainId: CHAIN_ID,
+          // Same members, same order as every honest node's set, so the
+          // epoch inside its vote signatures matches theirs.
+          validators: new ValidatorSet([...this.#validators]),
+          transport: this.network.createTransport(key),
+          spoof: (identity) => this.network.createTransport(identity),
+        })
+        this.byzantine.set(id, node)
+        this.events.record(id, 'fault', 'byzantine-node-added', {})
+      }
+      this.#pendingByzantine = []
+
       this.#built = true
     }
 

--- a/packages/test-harness/test/byzantine-proposer.test.ts
+++ b/packages/test-harness/test/byzantine-proposer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * An equivocating leader inside a cluster of real validator nodes.
+ *
+ * Every other fault this harness models makes a node stop — crash the leader,
+ * crash a follower, partition two against two, heal. None of that is a
+ * Byzantine fault, and Byzantine fault tolerance is the entire reason this
+ * codebase exists. Here the faulty node keeps running and keeps talking: it
+ * is a full member of the validator set, it signs everything correctly, and
+ * it tells two halves of the cluster two different things.
+ *
+ * The nodes it lies to are real `ValidatorNode`s with real state machines, so
+ * a successful attack shows up the way it would in production — as two honest
+ * nodes holding different state at the same height, which is exactly what
+ * `NoForkChecker` looks for.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  TransactionType,
+  encodeTx,
+  toHex,
+  type Block,
+  type Transaction,
+} from '@johnhenry/raijin-core'
+import { TestOrchestrator } from '../src/orchestrator.js'
+import { NoForkChecker } from '../src/checkers/no-fork.js'
+import { mockSign } from '../../consensus/test/helpers.js'
+
+/** A transfer signed the way the harness's nodes actually verify (see mockSign). */
+async function signedTransfer(
+  from: Uint8Array,
+  to: Uint8Array,
+  value: bigint,
+  nonce: bigint,
+): Promise<Transaction> {
+  const tx: Transaction = {
+    from,
+    to,
+    value,
+    nonce,
+    data: new Uint8Array([TransactionType.Transfer]),
+    signature: new Uint8Array(0),
+    chainId: 1n,
+  }
+  tx.signature = await mockSign(from)(encodeTx(tx))
+  return tx
+}
+
+/**
+ * A block a Byzantine leader hands out.
+ *
+ * `tag` fills `txRoot`, which makes two blocks distinguishable after the fact:
+ * it is part of the header (so it changes the consensus digest) and, unlike
+ * `stateRoot`/`receiptRoot`, execution never overwrites it.
+ */
+function byzantineBlock(
+  number: bigint,
+  proposer: Uint8Array,
+  transactions: Transaction[],
+  tag: number,
+): Block {
+  const txRoot = new Uint8Array(32)
+  txRoot.fill(tag)
+  return {
+    header: {
+      number,
+      parentHash: new Uint8Array(32),
+      stateRoot: new Uint8Array(32),
+      txRoot,
+      receiptRoot: new Uint8Array(32),
+      timestamp: 1_700_000_000_000,
+      proposer,
+    },
+    transactions,
+    signatures: [],
+  }
+}
+
+/**
+ * A 4-node cluster whose view-0 leader is Byzantine.
+ *
+ * Leader rotation is round-robin over registration order, so the liar is
+ * registered first. The three honest nodes are real validator nodes.
+ */
+async function equivocatingCluster(opts: { seed?: number } = {}) {
+  const orch = new TestOrchestrator(opts.seed !== undefined ? { seed: opts.seed } : undefined)
+  orch.addByzantineNode('liar') // leader for view 0
+  orch.addNode('b')
+  orch.addNode('c')
+  orch.addNode('d')
+  orch.startAll()
+
+  const liar = orch.byzantine.get('liar')!
+  const funder = orch.getKey('b')
+  const recipient = orch.getKey('d')
+  await orch.fundAccount(funder, 10_000n)
+
+  // Two blocks that cannot both be true: same height, same sequence,
+  // different transfers, therefore different post-state.
+  const blockA = byzantineBlock(1n, liar.publicKey, [await signedTransfer(funder, recipient, 10n, 0n)], 0xaa)
+  const blockB = byzantineBlock(1n, liar.publicKey, [await signedTransfer(funder, recipient, 500n, 0n)], 0xbb)
+
+  return { orch, liar, blockA, blockB }
+}
+
+describe('Byzantine proposer: 4-node cluster', () => {
+  /**
+   * n = 4, f = 1, quorum = 3. The liar is the leader, so the three honest
+   * nodes split 1 / 2. The lone node can gather at most two PREPAREs for its
+   * block — its own and the liar's — and never prepares. Only the pair can
+   * reach quorum, and only on one block.
+   *
+   * What is asserted is the safety property, not that anything threw: a
+   * Byzantine leader is entitled to be ignored in silence.
+   */
+  it('cannot make two honest nodes finalize different blocks at the same height', async () => {
+    const { orch, liar, blockA, blockB } = await equivocatingCluster()
+
+    await liar.equivocate({
+      view: 0n,
+      sequence: 1n,
+      groups: [
+        { targets: [orch.getKey('b')], block: blockA },
+        { targets: [orch.getKey('c'), orch.getKey('d')], block: blockB },
+      ],
+    })
+    await orch.drainFully()
+
+    // No two honest nodes hold different state at the same height. This is
+    // the property; everything below is detail that keeps the test honest.
+    const noFork = await orch.check(new NoForkChecker())
+    expect(noFork.passed, noFork.details).toBe(true)
+
+    // Whatever was finalized, it was one block — not one per group.
+    const tags = new Set(
+      [...orch.nodes.values()].flatMap((n) => n.finalizedBlocks.map((b) => b.header.txRoot[0])),
+    )
+    expect(tags.size).toBeLessThanOrEqual(1)
+
+    // Concretely: the isolated node finalized nothing, the pair finalized
+    // block B and agree on the resulting state. Stated so this test cannot
+    // pass by nothing happening at all.
+    expect(orch.nodes.get('b')!.finalizedBlocks).toHaveLength(0)
+    expect(orch.nodes.get('c')!.finalizedBlocks).toHaveLength(1)
+    expect(orch.nodes.get('d')!.finalizedBlocks).toHaveLength(1)
+    expect(orch.nodes.get('c')!.finalizedBlocks[0].header.txRoot[0]).toBe(0xbb)
+    expect(
+      toHex(orch.nodes.get('c')!.finalizedBlocks[0].header.stateRoot),
+    ).toBe(toHex(orch.nodes.get('d')!.finalizedBlocks[0].header.stateRoot))
+  })
+
+  /**
+   * The same attack under many message interleavings.
+   *
+   * FIFO delivery is one ordering out of enormously many, and a safety
+   * property that only holds under one ordering is not a safety property. The
+   * seeded delivery order (see `PartitionableNetwork.setDeliveryOrder`) picks
+   * a different interleaving per seed, and a failing seed is named in the
+   * assertion message so it can be replayed.
+   *
+   * SAFETY is asserted per seed. LIVENESS is not, and deliberately so: under
+   * some interleavings this round finalizes nothing at all, because
+   * `PBFTConsensus` discards a PREPARE or COMMIT whose sequence does not
+   * match the one it is currently on (`#handlePrepare`, `#handleCommit`) and
+   * never asks for it again. A vote that overtakes the proposal it refers to
+   * is simply lost, and the round waits for a view-change timeout. That is an
+   * ordinary reordering, not a fault, so it is worth being explicit that the
+   * sweep tolerates a stall and does not tolerate a fork.
+   */
+  it('cannot fork the cluster under any of a range of seeded message interleavings', async () => {
+    let seedsThatFinalized = 0
+    for (const seed of [1, 2, 3, 7, 42, 1337]) {
+      const { orch, liar, blockA, blockB } = await equivocatingCluster({ seed })
+      orch.network.setDeliveryOrder('random')
+
+      await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [
+          { targets: [orch.getKey('b')], block: blockA },
+          { targets: [orch.getKey('c'), orch.getKey('d')], block: blockB },
+        ],
+      })
+      await orch.drainFully()
+
+      const noFork = await orch.check(new NoForkChecker())
+      expect(noFork.passed, `seed ${seed}: ${noFork.details ?? ''}`).toBe(true)
+
+      const finalized = [...orch.nodes.values()].flatMap((n) => n.finalizedBlocks)
+      const tags = new Set(finalized.map((b) => b.header.txRoot[0]))
+      expect(tags.size, `seed ${seed}: honest nodes finalized ${tags.size} distinct blocks`)
+        .toBeLessThanOrEqual(1)
+
+      // Whatever this interleaving produced, the isolated node is never part
+      // of it — that is the shape a successful equivocation would have.
+      expect(orch.nodes.get('b')!.finalizedBlocks, `seed ${seed}`).toHaveLength(0)
+      if (finalized.length > 0) {
+        seedsThatFinalized++
+        expect([...tags], `seed ${seed}`).toEqual([0xbb])
+        expect(finalized.length, `seed ${seed}`).toBe(2)
+      }
+    }
+
+    // Safety is trivial when nothing happens anywhere, so the sweep is only
+    // evidence if some of it actually reached a decision. As measured, 3 of
+    // these 6 seeds finalize and 3 stall on the dropped-out-of-order-vote
+    // behaviour described above; the assertion is left loose rather than
+    // pinned to 3, because that number is a property of the current message
+    // handling and not something a Byzantine test should freeze.
+    expect(seedsThatFinalized).toBeGreaterThan(0)
+  })
+
+  /**
+   * A seed has to *mean* something.
+   *
+   * `setDeliveryOrder('random')` is only worth having if a seed names one
+   * reproducible interleaving — otherwise "it failed under seed 42" is not a
+   * bug report, and sweeping seeds is not coverage. This measures both halves
+   * of that claim against the network's own delivery log: the same seed
+   * replays exactly, and two different seeds do not produce the same run.
+   */
+  it('replays exactly under one seed and diverges under another', async () => {
+    async function run(seed: number): Promise<string> {
+      const { orch, liar, blockA, blockB } = await equivocatingCluster({ seed })
+      orch.network.setDeliveryOrder('random')
+      await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [
+          { targets: [orch.getKey('b')], block: blockA },
+          { targets: [orch.getKey('c'), orch.getKey('d')], block: blockB },
+        ],
+      })
+      await orch.drainFully()
+      return orch.network.deliveryLog.map((d) => `${d.type} ${d.from}->${d.to}`).join('|')
+    }
+
+    const a1 = await run(42)
+    const a2 = await run(42)
+    const b1 = await run(43)
+
+    expect(a1.length).toBeGreaterThan(0)
+    expect(a2).toBe(a1)          // same seed, same interleaving
+    expect(b1).not.toBe(a1)      // a different seed is a different run
+  })
+})

--- a/packages/test-harness/test/network-faults.test.ts
+++ b/packages/test-harness/test/network-faults.test.ts
@@ -1,0 +1,148 @@
+/**
+ * What `PartitionableNetwork` can actually do to a message.
+ *
+ * The harness advertises drop, delay, partition and (now) reordering, all
+ * driven from a seed. Those claims are load-bearing — a Byzantine or
+ * partition test is only worth the interleavings it covers, and "seed 1337
+ * fails" is only a bug report if seed 1337 replays. Nothing measured them, so
+ * this file does, against the network alone rather than through consensus:
+ * a fault primitive that is broken should fail here, not show up three layers
+ * up as a consensus round that mysteriously stalls.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import type { ConsensusMessage } from '@johnhenry/raijin-consensus'
+import { PartitionableNetwork } from '../src/network/partitionable-network.js'
+import { SeededPRNG } from '../src/network/seeded-prng.js'
+import { makeTestKey } from '../../consensus/test/helpers.js'
+
+/** A message with just enough shape to travel. Contents are irrelevant here. */
+function note(sequence: bigint): ConsensusMessage {
+  return {
+    type: 'prepare',
+    view: 0n,
+    sequence,
+    digest: new Uint8Array(32),
+    from: new Uint8Array(32),
+    signature: new Uint8Array(0),
+  }
+}
+
+/** Two peers, B recording what it receives. */
+function pair(seed?: number) {
+  const net = new PartitionableNetwork()
+  if (seed !== undefined) net.setPRNG(new SeededPRNG(seed))
+  const a = makeTestKey(1)
+  const b = makeTestKey(2)
+  const received: bigint[] = []
+  const ta = net.createTransport(a)
+  const tb = net.createTransport(b)
+  tb.onMessage((_from, msg) => {
+    received.push((msg as { sequence: bigint }).sequence)
+  })
+  // A must be registered too, or broadcasts have nowhere to go.
+  net.createTransport(a).onMessage(() => {})
+  return { net, a, b, ta, received }
+}
+
+describe('PartitionableNetwork fault primitives', () => {
+  it('drops messages on an edge at the configured rate', async () => {
+    const { net, a, b, ta, received } = pair(7)
+    net.addDropRate(a, b, 1)
+    for (let i = 0n; i < 10n; i++) ta.send(b, note(i))
+    await net.drainAll()
+    expect(received).toHaveLength(0)
+
+    net.removeDropRate(a, b)
+    for (let i = 0n; i < 10n; i++) ta.send(b, note(i))
+    await net.drainAll()
+    expect(received).toHaveLength(10)
+  })
+
+  it('drops the same messages on two runs of the same seed, and different ones on another', async () => {
+    const run = async (seed: number): Promise<bigint[]> => {
+      const { net, a, b, ta, received } = pair(seed)
+      net.addDropRate(a, b, 0.5)
+      for (let i = 0n; i < 40n; i++) ta.send(b, note(i))
+      await net.drainAll()
+      return received
+    }
+    const first = await run(7)
+    expect(first.length).toBeGreaterThan(0)
+    expect(first.length).toBeLessThan(40)
+    expect(await run(7)).toEqual(first)
+    expect(await run(8)).not.toEqual(first)
+  })
+
+  it('holds a delayed message until logical time reaches it', async () => {
+    const { net, a, b, ta, received } = pair()
+    net.addDelay(a, b, 500)
+    ta.send(b, note(1n))
+
+    expect(await net.drainAll()).toBe(0)
+    expect(received).toHaveLength(0)
+    expect(net.pending).toBe(1)
+
+    net.advanceTime(499)
+    expect(await net.drainAll()).toBe(0)
+    expect(received).toHaveLength(0)
+
+    net.advanceTime(1)
+    expect(await net.drainAll()).toBe(1)
+    expect(received).toEqual([1n])
+  })
+
+  it('blocks a partitioned edge in both directions and restores it on heal', async () => {
+    const { net, a, b, ta, received } = pair()
+    net.partition([a], [b])
+    ta.send(b, note(1n))
+    await net.drainAll()
+    expect(received).toHaveLength(0)
+    expect(net.pending).toBe(1) // held, not discarded — that is what makes it reversible
+
+    net.healPartition()
+    await net.drainAll()
+    expect(received).toEqual([1n])
+  })
+
+  it('preserves each link own order while reordering across links', async () => {
+    // Three senders into one receiver. Under 'random' the receiver may see
+    // the senders interleaved in any order, but each sender's own messages
+    // must arrive in the order that sender sent them — that is what an
+    // ordered DataChannel or a WebSocket guarantees, and reordering a
+    // sender behind itself would model a transport nobody deploys.
+    const net = new PartitionableNetwork()
+    net.setPRNG(new SeededPRNG(99))
+    net.setDeliveryOrder('random')
+
+    const dest = makeTestKey(9)
+    const seen: string[] = []
+    net.createTransport(dest).onMessage((from, msg) => {
+      seen.push(`${from[0]}:${(msg as { sequence: bigint }).sequence}`)
+    })
+
+    for (const id of [1, 2, 3]) {
+      const t = net.createTransport(makeTestKey(id))
+      for (let i = 0n; i < 5n; i++) t.send(dest, note(i))
+    }
+    await net.drainAll()
+
+    expect(seen).toHaveLength(15)
+    for (const id of [1, 2, 3]) {
+      const own = seen.filter((s) => s.startsWith(`${id}:`))
+      expect(own, `sender ${id} out of order`).toEqual(
+        [0, 1, 2, 3, 4].map((i) => `${id}:${i}`),
+      )
+    }
+    // And the senders really were interleaved, or "preserves order" would be
+    // a claim about a run that never reordered anything.
+    const senderSequence = seen.map((s) => s[0]).join('')
+    expect(senderSequence).not.toBe('111112222233333')
+  })
+
+  it('refuses seeded reordering without a seed rather than silently staying FIFO', () => {
+    const net = new PartitionableNetwork()
+    expect(() => net.setDeliveryOrder('random')).toThrow(/setPRNG/)
+  })
+})

--- a/packages/test-harness/vitest.config.ts
+++ b/packages/test-harness/vitest.config.ts
@@ -1,8 +1,41 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
+
+const src = (pkg: string) =>
+  fileURLToPath(new URL(`../${pkg}/src/index.ts`, import.meta.url))
 
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
     testTimeout: 30000,
+  },
+  resolve: {
+    /**
+     * Resolve the workspace packages to their SOURCE, not to their built
+     * `dist`.
+     *
+     * Every other package's suite runs against `src` (it imports relatively).
+     * This one did not: `@johnhenry/raijin-*` resolves through the package
+     * `exports` map to `dist/index.js`, so the harness was testing whatever
+     * was last built. Two ways that goes wrong, both silent:
+     *
+     *  - a change to consensus or validator source that nobody rebuilt is not
+     *    covered here at all, and the suite reports green for code that is not
+     *    the code in the tree;
+     *  - the harness reaches directly into `../../consensus/test/helpers.ts`
+     *    (see `src/index.ts`), which is source. Mixing a source helper with a
+     *    built package means two copies of `ValidatorSet` and two versions of
+     *    the vote payload — and a payload mismatch is an invalid signature,
+     *    which looks like consensus quietly refusing to make progress rather
+     *    than like a build problem.
+     *
+     * Pointing at source removes both. Nothing here needs the bundler.
+     */
+    alias: {
+      '@johnhenry/raijin-core': src('core'),
+      '@johnhenry/raijin-consensus': src('consensus'),
+      '@johnhenry/raijin-mempool': src('mempool'),
+      '@johnhenry/raijin-validator': src('validator'),
+    },
   },
 })

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -2,7 +2,7 @@
 
 Composition root wiring core, consensus, and mempool into a runnable validator node for the [Raijin](https://github.com/johnhenry/raijin) mesh rollup — a browser-native rollup framework where the users ARE the validators.
 
-`ValidatorNode` assembles a `StateMachine`, a `PBFTConsensus` engine, a FIFO `Mempool`, and a `BlockProducer`, then runs the loop: accept transactions → (if leader) build a block on the block timer → propose → finalize → apply state → prune mempool. You inject identity (keys + sign/verify), a network transport, a timer, and a state store — the node is transport-, storage-, and identity-agnostic.
+`ValidatorNode` assembles a `StateMachine`, a `PBFTConsensus` engine, the fee-ordered `Mempool` from `@johnhenry/raijin-mempool`, and a `BlockProducer`, then runs the loop: accept transactions → (if leader) build a block on the block timer → propose → finalize → apply state → prune mempool. You inject identity (keys + sign/verify), a network transport, a timer, and a state store — the node is transport-, storage-, and identity-agnostic.
 
 ## Install
 
@@ -12,11 +12,13 @@ npm install @johnhenry/raijin-validator
 
 ## Traps first
 
-- **This package's `Mempool` is not `@johnhenry/raijin-mempool`.** It's a separate, simpler class: FIFO order (no fee ordering), **no signature verification**, and `add()` **throws** `'Mempool full'` at capacity instead of evicting. The fee-ordered, verifying pool in `@johnhenry/raijin-mempool` is not wired into `ValidatorNode` today.
-- **`submitTransaction()` accepts anything.** Invalid signatures, bad nonces, and overspends are only caught when the block executes — they become `revert` receipts, but they still occupied mempool and block space on the way.
+- **`chainId` is required and has no default.** It is signed into every consensus vote; a default would be an id shared by every deployment that never chose one, letting votes replay between them. Give two different deployments two different ids.
+- **`Mempool` is re-exported from `@johnhenry/raijin-mempool`.** This package used to ship its own simpler FIFO class of the same name; it no longer does. `ValidatorNode` wires the real one: fee-ordered, sender+nonce deduplicated, signature-verified against the same `SignatureVerifier` the state machine uses, and evicting the lowest-fee transaction when full rather than throwing. `import { Mempool } from '@johnhenry/raijin-validator'` still works and now gives you that pool.
+- **`submitTransaction()` rejects rather than accepts-and-reverts.** An invalid signature, a duplicate sender+nonce, or a full pool with nothing cheaper to evict all make it **throw**, before the transaction ever occupies block space. A bad *nonce* is still only caught at execution, as a `revert` receipt — the mempool deduplicates nonces but does not know the account's current one.
 - **`validators` must include this node's own public key**, or `isLeader` is never true and (with `n = 1`) nothing ever finalizes. All nodes must pass the same keys in the same order.
-- **Block headers commit to transactions, not to state.** `BlockProducer` fills `txRoot` from the transactions but leaves `stateRoot`/`receiptRoot` zeroed ("filled after execution" — currently never filled), and `advance()` uses the previous header's `stateRoot` field as `parentHash`. Consensus therefore agrees on *transaction ordering*, and state agreement is by construction (same deterministic state machine), not by header commitment.
-- **Quorum below 4 validators is 1.** See `@johnhenry/raijin-consensus` — a single-validator "network" finalizes its own blocks instantly, which is exactly what the quick start below exploits.
+- **Block headers commit to transactions *and* to state.** `BlockProducer` fills `txRoot` up front and leaves `stateRoot`/`receiptRoot` zeroed in the proposal, because neither can be known before the block runs — the consensus digest is taken over that pre-execution header. PBFT then fills in the real `stateRoot` and `receiptRoot` after applying the block, and `advance()` hashes *that* completed header for the next block's `parentHash`. So the chain link commits to the executed result, while the digest nodes voted on commits to the proposal.
+- **`parentHash` is the parent's block hash**, `blockHash(parent)` = `H(encodeBlockHeader(parent.header))` — not the parent's state root, which is what it used to be. It therefore commits to the parent's transactions, proposer, timestamp and roots, so "same height, different history" is detectable from headers alone.
+- **Quorum is `n - f`, not `2f + 1`.** At `n = 1` quorum is 1 (which is what the single-node quick start below exploits), but at `n = 2` it is 2 and at `n = 3` it is 3 — a single node cannot finalize alone at any validator count. You still get no fault *tolerance* below `n = 4`. See `@johnhenry/raijin-consensus`.
 
 ## Quick start — a one-validator chain
 
@@ -25,7 +27,8 @@ import { InMemoryStateStore } from '@johnhenry/raijin-core'
 import { ValidatorNode } from '@johnhenry/raijin-validator'
 
 const node = new ValidatorNode({
-  identity: { publicKey, sign, verify },   // your keys; verify checks tx signatures
+  chainId: 1n,                             // required — no default
+  identity: { publicKey, sign, verify },   // your keys; verify checks tx AND vote signatures
   transport: { broadcast() {}, send() {}, onMessage() {} }, // single node: no peers
   timer: { set: (ms, cb) => setTimeout(cb, ms), clear: clearTimeout },
   store: new InMemoryStateStore(),
@@ -45,12 +48,14 @@ With one validator the node is always leader: the block timer fires, `BlockProdu
 
 ### `ValidatorNode` / `ValidatorNodeConfig`
 
-Config: `identity` (`{ publicKey, sign, verify }`), `transport` (`NetworkTransport`), `timer` (`ConsensusTimer`), `store` (`StateStore`), plus optional `blockTime` (ms, default 2000), `validators` (default `[]` — see trap above), `maxTxPerBlock` (default 100), `maxMempoolSize` (default 4096).
+Config: `chainId` (**required**, `bigint`), `identity` (`{ publicKey, sign, verify }`), `transport` (`NetworkTransport`), `timer` (`ConsensusTimer`), `store` (`StateStore`), plus optional `blockTime` (ms, default 2000), `validators` (default `[]` — see trap above), `maxTxPerBlock` (default 100), `maxMempoolSize` (default 4096).
+
+`identity.verify` is used for two different jobs: the state machine and the mempool check transaction signatures with it, and consensus checks every PRE-PREPARE/PREPARE/COMMIT/VIEW-CHANGE vote with it. A verifier that returns `true` unconditionally therefore disables vote authentication as well as transaction validation.
 
 | Member | Purpose |
 | --- | --- |
 | `start()` / `stop()` | Start/stop consensus and the block-production timer loop. Idempotent. |
-| `submitTransaction(tx): Promise<string>` | Adds to the FIFO mempool; resolves to the tx hash hex (hash of the *signed* encoding). Throws if the mempool is full. |
+| `submitTransaction(tx): Promise<string>` | Verifies and adds to the mempool; resolves to the tx hash hex (hash of the *signed* encoding). Throws on an invalid signature, a duplicate sender+nonce, or a full pool. |
 | `onBlockFinalized(handler)` | `(block, receipts) => void` after every finalized block. |
 | `latestBlock` | Most recently finalized `Block`, or `null`. |
 | `running` | Boolean. |
@@ -63,20 +68,22 @@ Block-production errors inside the timer loop are swallowed by design (not being
 Config: `proposer` (pubkey), `consensus`, `mempool`, optional `maxTxPerBlock` (default 100).
 
 - `produceBlock(): Promise<Block | null>` — returns `null` when not leader or mempool empty; otherwise builds a block (Merkle `txRoot` over signed-tx hashes) and calls `consensus.propose()`.
-- `advance(block)` — called after finalization to bump `nextBlockNumber` and carry the parent linkage.
+- `advance(block): Promise<void>` — called after finalization to bump `nextBlockNumber` and set the next `parentHash` to `await blockHash(block)`. **Async** — it hashes the parent header, so callers must `await` it.
 - `nextBlockNumber: bigint` — getter.
 
-### `Mempool` (the FIFO one)
+### `Mempool` (re-exported)
 
-`new Mempool(maxSize = 4096)` — `add(tx): Promise<string>` (throws when full), `pending(limit?)` (FIFO), `remove(hashHex)`, `removeBatch(txs)`, `clear()`, `size`. Keyed by hash of the signed encoding, so the same signed tx submitted twice occupies one slot.
+`export { Mempool } from '@johnhenry/raijin-mempool'` — a convenience re-export, not a separate implementation. See that package's README for the full API (`submit`, `pendingForProposer`, `removeBatch`, the fee convention and the eviction rule). `ValidatorNode` constructs it with `maxSize: maxMempoolSize` and a verifier built from `identity.verify`.
 
 ## Running more than one node
 
 Everything above scales to a real mesh, but three things change:
 
-1. **The transport becomes real.** Every node's `transport.broadcast`/`send` must reach every other validator, and `onMessage` must report the sender's actual public key as `from` — consensus trusts that value, so an unauthenticated transport means any peer can impersonate any validator. If your wire format is JSON, consensus messages carry `bigint`s and `Uint8Array`s; you need a replacer/reviver pair (`packages/consensus/test/helpers.ts` has a working one).
+1. **The transport becomes real.** Every node's `transport.broadcast`/`send` must reach every other validator, and `onMessage` reports the sender's public key as `from`. Consensus no longer *trusts* that value — every vote's signature is verified against it, so a transport that lies about `from` produces messages that fail verification and are dropped. What the transport still owes you is delivery: nothing here retries or reorders, so a lossy transport costs liveness, not safety. If your wire format is JSON, consensus messages carry `bigint`s and `Uint8Array`s; you need a replacer/reviver pair (`packages/consensus/test/helpers.ts` has a working one).
 2. **`validators` must be byte-identical on every node** — same keys, same order. Leader election is positional (`view % n`), so a different ordering means nodes disagree about who may propose and nothing ever finalizes, with no error to tell you why.
-3. **Quorum math starts to matter.** At n = 4 you tolerate one faulty node (quorum 3); below that, quorum is 1 and any single node can finalize alone. Pick n = 3f + 1 for the f you actually need.
+3. **Quorum math starts to matter.** Quorum is `n - f` with `f = floor((n - 1) / 3)`: at n = 4 you tolerate one faulty node (quorum 3), at n = 3 quorum is 3 and you tolerate none. Pick n = 3f + 1 for the f you actually need — that is where `n - f` is also the minimum, `2f + 1`.
+
+4. **Every node needs the same `chainId`**, and two different deployments need two different ones. That is what stops one network's votes being counted by the other.
 
 Multi-node scenarios — leader crashes, partitions, membership churn — are exercised by the repo's internal `raijin-test-harness` package (`TestOrchestrator` + `PartitionableNetwork` + invariant checkers) rather than examples, because they're timing-sensitive by nature. Read the harness tests for working multi-node wiring.
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -77,7 +77,7 @@ Config: `proposer` (pubkey), `consensus`, `mempool`, optional `maxTxPerBlock` (d
 
 ## Running more than one node
 
-Everything above scales to a real mesh, but three things change:
+Everything above scales to a real mesh, but four things change:
 
 1. **The transport becomes real.** Every node's `transport.broadcast`/`send` must reach every other validator, and `onMessage` reports the sender's public key as `from`. Consensus no longer *trusts* that value — every vote's signature is verified against it, so a transport that lies about `from` produces messages that fail verification and are dropped. What the transport still owes you is delivery: nothing here retries or reorders, so a lossy transport costs liveness, not safety. If your wire format is JSON, consensus messages carry `bigint`s and `Uint8Array`s; you need a replacer/reviver pair (`packages/consensus/test/helpers.ts` has a working one).
 2. **`validators` must be byte-identical on every node** — same keys, same order. Leader election is positional (`view % n`), so a different ordering means nodes disagree about who may propose and nothing ever finalizes, with no error to tell you why.

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-validator",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Composition root wiring core, consensus, and mempool into a runnable validator node",
   "repository": {
     "type": "git",
@@ -29,9 +29,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@johnhenry/raijin-core": "^0.0.0",
-    "@johnhenry/raijin-consensus": "^0.0.0",
-    "@johnhenry/raijin-mempool": "^0.0.0"
+    "@johnhenry/raijin-core": "^0.0.1",
+    "@johnhenry/raijin-consensus": "^0.0.1",
+    "@johnhenry/raijin-mempool": "^0.0.1"
   },
   "devDependencies": {
     "typescript": "^5.7",

--- a/packages/validator/src/block-producer.ts
+++ b/packages/validator/src/block-producer.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Block, Transaction } from '@johnhenry/raijin-core'
-import { hash, merkleRoot, encodeTxSigned } from '@johnhenry/raijin-core'
+import { hash, merkleRoot, encodeTxSigned, blockHash } from '@johnhenry/raijin-core'
 import type { PBFTConsensus } from '@johnhenry/raijin-consensus'
 import type { Mempool } from '@johnhenry/raijin-mempool'
 
@@ -25,7 +25,7 @@ export class BlockProducer {
   #mempool: Mempool
   #maxTxPerBlock: number
   #nextBlockNumber = 1n
-  #parentHash = new Uint8Array(32)
+  #parentHash: Uint8Array = new Uint8Array(32)
 
   constructor(config: BlockProducerConfig) {
     this.#proposer = config.proposer
@@ -46,12 +46,23 @@ export class BlockProducer {
     return block
   }
 
-  /** Update state after a block is finalized. */
-  advance(block: Block): void {
+  /**
+   * Update state after a block is finalized.
+   *
+   * `parentHash` is the parent's canonical block hash -- SHA-256 over its
+   * encoded header. It used to be the parent's *state root*, which commits to
+   * the resulting account state and to nothing else: not the transactions, the
+   * proposer, the timestamp, the txRoot or the receiptRoot. Two different
+   * blocks leaving the same post-state (any two blocks whose transactions all
+   * revert, for instance) were then indistinguishable as parents, and an empty
+   * block's child pointed at a hash equal to the block's own.
+   *
+   * `advance()` runs after PBFT has filled in the real stateRoot and
+   * receiptRoot, so the hash covers the executed result.
+   */
+  async advance(block: Block): Promise<void> {
     this.#nextBlockNumber = block.header.number + 1n
-    // Use a hash of the block number as parent hash (simplified)
-    // In production, this would be the actual block hash
-    this.#parentHash = new Uint8Array(block.header.stateRoot)
+    this.#parentHash = await blockHash(block)
   }
 
   /** Current next block number. */

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -21,6 +21,13 @@ import { Mempool } from '@johnhenry/raijin-mempool'
 import { BlockProducer } from './block-producer.js'
 
 export interface ValidatorNodeConfig {
+  /**
+   * Chain identifier — which deployment this node belongs to. Required, with
+   * no default: it is signed into every consensus vote, and a default id is
+   * one that every deployment which never chose one would share, letting
+   * votes replay between them. See `PBFTConfig.chainId`.
+   */
+  chainId: bigint
   /** This node's identity. */
   identity: {
     publicKey: Uint8Array
@@ -58,6 +65,7 @@ export class ValidatorNode {
 
   constructor(config: ValidatorNodeConfig) {
     const {
+      chainId,
       identity,
       transport,
       timer,
@@ -90,6 +98,7 @@ export class ValidatorNode {
     // Create consensus engine
     this.#consensus = new PBFTConsensus({
       identity: identity.publicKey,
+      chainId,
       validators: this.#validatorSet,
       transport,
       timer,

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -200,7 +200,7 @@ export class ValidatorNode {
     this.#mempool.removeBatch(block.transactions)
 
     // Advance block producer state
-    this.#blockProducer.advance(block)
+    await this.#blockProducer.advance(block)
 
     // Notify external handlers
     for (const handler of this.#onBlockFinalizedHandlers) {

--- a/packages/validator/test/block-producer.test.ts
+++ b/packages/validator/test/block-producer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   InMemoryStateStore,
   TransactionType,
+  accountKey,
   encodeAccount,
   encodeTxSigned,
   blockHash,
@@ -82,11 +83,7 @@ const alice = makeKey(1)
 const bob = makeKey(2)
 
 async function fundAccount(store: InMemoryStateStore, address: Uint8Array, balance: bigint): Promise<void> {
-  const prefix = new TextEncoder().encode('account:')
-  const key = new Uint8Array(prefix.length + address.length)
-  key.set(prefix, 0)
-  key.set(address, prefix.length)
-  await store.put(key, encodeAccount({ balance, nonce: 0n, reputation: 0n }))
+  await store.put(accountKey(address), encodeAccount({ balance, nonce: 0n, reputation: 0n }))
 }
 
 describe('BlockProducer / ValidatorNode — receipt & chain-linkage integrity', () => {

--- a/packages/validator/test/block-producer.test.ts
+++ b/packages/validator/test/block-producer.test.ts
@@ -96,6 +96,7 @@ describe('BlockProducer / ValidatorNode — receipt & chain-linkage integrity', 
   beforeEach(async () => {
     store = new InMemoryStateStore()
     node = new ValidatorNode({
+      chainId: 1n,
       identity: {
         publicKey: alice,
         sign: async () => alice,

--- a/packages/validator/test/block-producer.test.ts
+++ b/packages/validator/test/block-producer.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionType,
   encodeAccount,
   encodeTxSigned,
+  blockHash,
   hash,
   merkleRoot,
   equal,
@@ -138,15 +139,44 @@ describe('BlockProducer / ValidatorNode — receipt & chain-linkage integrity', 
     expect(equal(recomputedTxRoot, block.header.txRoot)).toBe(true)
   })
 
-  it('chains parentHash to the previous block real (non-zero) stateRoot', async () => {
+  it("chains parentHash to the parent's canonical block hash, not to its stateRoot", async () => {
     const tx1 = makeTransfer(alice, bob, 100n, 0n)
     const { block: block1 } = await produceAndFinalize(tx1)
 
+    // The parent must have been executed before it can be hashed: a header
+    // still carrying zero placeholders would link the chain to nothing.
     expect(block1.header.stateRoot).not.toEqual(new Uint8Array(32))
+    expect(block1.header.receiptRoot).not.toEqual(new Uint8Array(32))
 
     const tx2 = makeTransfer(alice, bob, 50n, 1n)
     const { block: block2 } = await produceAndFinalize(tx2)
 
-    expect(equal(block2.header.parentHash, block1.header.stateRoot)).toBe(true)
+    // What this pins: the link between two blocks is a commitment to the
+    // parent's whole header — number, parentHash, stateRoot, txRoot,
+    // receiptRoot, timestamp and proposer — so a child names exactly one
+    // possible parent.
+    expect(equal(block2.header.parentHash, await blockHash(block1))).toBe(true)
+
+    // And what it pins against: parentHash used to be the parent's *state
+    // root*, which commits to the resulting account state and to nothing
+    // else. Two different blocks that leave the same post-state (any two
+    // whose transactions all revert, say) were indistinguishable as parents.
+    expect(equal(block2.header.parentHash, block1.header.stateRoot)).toBe(false)
+  })
+
+  it('gives two blocks with an identical post-state distinct block hashes', async () => {
+    // The concrete failure the stateRoot link could not see. These two
+    // headers agree on everything the old link covered (stateRoot) and
+    // differ in the transactions they contain (txRoot), which is exactly the
+    // pair a parent pointer has to tell apart.
+    const { block } = await produceAndFinalize(makeTransfer(alice, bob, 100n, 0n))
+
+    const sameState: Block = {
+      ...block,
+      header: { ...block.header, txRoot: new Uint8Array(32).fill(9) },
+    }
+
+    expect(equal(sameState.header.stateRoot, block.header.stateRoot)).toBe(true)
+    expect(equal(await blockHash(sameState), await blockHash(block))).toBe(false)
   })
 })

--- a/packages/validator/test/validator.test.ts
+++ b/packages/validator/test/validator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import {
   InMemoryStateStore,
   TransactionType,
+  accountKey,
   encodeAccount,
   type Transaction,
   type SignatureVerifier,
@@ -177,11 +178,7 @@ describe('ValidatorNode', () => {
     })
 
     // Fund alice
-    const key = new TextEncoder().encode('account:')
-    const fullKey = new Uint8Array(key.length + alice.length)
-    fullKey.set(key, 0)
-    fullKey.set(alice, key.length)
-    await store.put(fullKey, encodeAccount({ balance: 10000n, nonce: 0n, reputation: 0n }))
+    await store.put(accountKey(alice), encodeAccount({ balance: 10000n, nonce: 0n, reputation: 0n }))
   })
 
   it('starts and stops cleanly', () => {

--- a/packages/validator/test/validator.test.ts
+++ b/packages/validator/test/validator.test.ts
@@ -162,6 +162,7 @@ describe('ValidatorNode', () => {
     transport = new LoopbackTransport(alice)
 
     node = new ValidatorNode({
+      chainId: 1n,
       identity: {
         publicKey: alice,
         sign: async (msg) => alice,
@@ -208,6 +209,7 @@ describe('ValidatorNode', () => {
 
   it('rejects a transaction with a bad signature before it enters the mempool', async () => {
     const badNode = new ValidatorNode({
+      chainId: 1n,
       identity: {
         publicKey: alice,
         sign: async () => alice,
@@ -240,6 +242,7 @@ describe('ValidatorNode', () => {
     // Create a node that is NOT the leader (bob, but leader rotation gives alice view 0)
     const bobTransport = new LoopbackTransport(bob)
     const bobNode = new ValidatorNode({
+      chainId: 1n,
       identity: {
         publicKey: bob,
         sign: async (msg) => bob,


### PR DESCRIPTION
The five commits that PR #29 left behind. Its branch was merged at `a9b2b98`, five
commits before the work was finished, so `main` currently has the nine security fixes and
none of what follows.

## A node that lies (`534cd7a`, `a98f73a`)

`grep` for `byzantine|equivocat|malicious|forge` across the harness and validator tests
returned **zero** before this. The harness modelled crash faults and partitions only — the
unit tests forged messages well, but nothing forged a *node*. For a library whose reason to
exist is Byzantine fault tolerance, the fault model it exists for was untested.

Both new tests were proven non-vacuous by injection:

- Restoring the old `2f+1` quorum finalized **two distinct blocks across honest replicas,
  with no forgery anywhere** — a real fork.
- Unbinding a vote signature from its phase let a block **finalize on a manufactured commit
  quorum**.

## The last raw concatenation (`13b455f`)

`stateKey()` joined namespace and id with no length prefix and no tag — the final unprefixed
concatenation of two variable-length values in the tree, unambiguous only by accident of
which namespaces happen to exist. Domain-tagged and length-prefixed like the rest.

## Every documented claim, checked (`6483328`)

Thirty claims verified against the code. Ten confirmed still true and left exactly as they
were. The rest corrected — including one that was actively dangerous (`consensus/README.md`
told readers signatures were "collected, not verified" and that authentication was their
transport's job, after this work made it the engine's), and one that was copy-pasteable and
wrong: the SDK's receipt-correlation recipe used `hash(encodeTx(tx))` where receipts are keyed
by `encodeTxSigned` — code that compiles, runs, and never matches.

## 0.0.1, with the ranges and publish order it needs (`110bd27`)

`0.0.1` does **not** satisfy `^0.0.0` (`npx semver 0.0.1 -r "^0.0.0"` exits 1), and all six
packages are already live at 0.0.0. Bumping versions alone would have published
`validator@0.0.1` depending on `core@^0.0.0` and installed the old, vulnerable core. Every
internal range moves with the versions.

The publish workflow ran `npm publish --workspaces`, which iterates **alphabetically** —
consensus before core — so every dependent would have been published against a `core@^0.0.1`
that did not yet exist. Now explicit and dependency-ordered.

`MIGRATION.md` gained the row it was missing: `PrePrepareMessage` gained required `from` and
`signature`, where main had neither. That is the one break a reader could not infer from the
digest rows, and it fails silently — a hand-rolled JSON transport that drops the two fields
produces a chain that never finalises and reports no error.

---

Verified on this branch: `npx turbo run test --force` EXIT 0, 13/13 tasks uncached, **254
passed, 0 failed**. `npx turbo run typecheck --force` EXIT 0, 10/10 uncached. `npm run
examples` EXIT 0.
