### PR TITLE
fix(consensus): full prepared-certificate carry-over on view change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 0.0.2 (2026-09-06)
+
+**`@johnhenry/raijin-consensus`**
+
+- **Full prepared-certificate carry-over on view change.** `#doViewChange`
+  previously only guarded against a *conflicting* re-proposal at a sequence
+  that was already validly prepared in a prior view (`#preparedCert`); it
+  could not get the original block re-proposed, so a view change stalled
+  progress even when the new leader itself had prepared the block. The new
+  leader now automatically re-proposes the block it already prepared (kept
+  in the new `#preparedBlock` map, alongside `#preparedCert`) the moment it
+  becomes leader — no external `propose()` call needed. A new leader with no
+  certificate for the sequence (never having seen the round) still falls
+  back to normal block production, and the existing conflict guard is
+  unchanged. See `packages/consensus/test/byzantine.test.ts` — "a new leader
+  that already prepared the block automatically re-proposes and finalizes
+  it".
+
+**`@johnhenry/raijin-validator`**
+
+- No code change. Version bump only, to pull in the fixed
+  `@johnhenry/raijin-consensus@^0.0.2`.
+
+**`raijin-test-harness`** (internal, unpublished)
+
+- `SeededPRNG.next()` now returns the high 53 bits of the xorshift128+ word
+  instead of the low 53 bits — the low bits of xorshift128+ fail linearity
+  tests that the high bits pass, which is the standard reason to avoid them
+  in a float generator.
+- Added test coverage for `removeDelay` and `resetFaults`, previously
+  unexercised by any test.
+
 ## 0.0.1 — the first release that is safe to run (2026-09-04)
 
 All six published packages, together. **Upgrade from `0.0.0`.**

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ What it provides:
 
 Why it stays unpublished: it reaches into `../../consensus/test/helpers.ts`
 for its mock network/timer (a path that only exists in this repo), and its
-multi-node tests are timing-sensitive by nature — the 25 harness tests are
+multi-node tests are timing-sensitive by nature — the 27 harness tests are
 known to be flaky under load, which is acceptable for internal scenario
-testing but not something to ship. The 229 tests across the six publishable
+testing but not something to ship. The 230 tests across the six publishable
 packages are deterministic; CI's example smoke step is also restricted to
 single-node scenarios for the same reason (see
 [examples/README.md](examples/README.md)).
@@ -112,6 +112,23 @@ that sends two different blocks for one sequence, and votes replayed across
 phases. Both were proven non-vacuous by injection — restoring the old
 `2f+1` quorum produces a real fork across honest replicas, and unbinding a
 vote's phase lets a block finalize on a manufactured commit quorum.
+
+## Validator-set size
+
+Quorum is `n - f` where `f = maxFaults = floor((n - 1) / 3)` (see
+`ValidatorSet.quorumSize`/`maxFaults`, asserted in
+`packages/consensus/test/validator-set.test.ts`). That formula is safe at
+*any* `n`, but it only tolerates a fault when `n >= 3f + 1` with `f >= 1`,
+i.e. **`n >= 4`**:
+
+| `n` | `f` (tolerated faults) | quorum | notes |
+|---|---|---|---|
+| 1–3 | 0 | `n` | safety holds, but *every* validator must be online and honest — one crash or lie halts the cluster. `smoke.test.ts` / the 3-node `multi-block.test.ts` / `credit-transfer.test.ts` scenarios run here deliberately, as the happy-path/no-fault case. |
+| 4–6 | 1 | `n - 1` | smallest configuration with real Byzantine tolerance. Every Byzantine test in `packages/consensus/test/byzantine.test.ts` and the 4-validator harness scenarios run at `n = 4`. |
+| `3f + 1`+ | `f` | `n - f` | general case. |
+
+There is no supported *upper* bound enforced in code; larger `n` has not
+been load-tested here.
 
 ## Design Principles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raijin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raijin",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2237,7 +2237,7 @@
     },
     "packages/consensus": {
       "name": "@johnhenry/raijin-consensus",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
         "@johnhenry/raijin-core": "^0.0.1"
@@ -2309,9 +2309,9 @@
       "name": "raijin-test-harness",
       "version": "0.1.0",
       "dependencies": {
-        "@johnhenry/raijin-consensus": "^0.0.1",
+        "@johnhenry/raijin-consensus": "^0.0.2",
         "@johnhenry/raijin-core": "^0.0.1",
-        "@johnhenry/raijin-validator": "^0.0.1"
+        "@johnhenry/raijin-validator": "^0.0.2"
       },
       "devDependencies": {
         "typescript": "^5.7",
@@ -2320,10 +2320,10 @@
     },
     "packages/validator": {
       "name": "@johnhenry/raijin-validator",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@johnhenry/raijin-consensus": "^0.0.1",
+        "@johnhenry/raijin-consensus": "^0.0.2",
         "@johnhenry/raijin-core": "^0.0.1",
         "@johnhenry/raijin-mempool": "^0.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raijin",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Browser-native mesh rollup framework. Build sovereign rollups where the users ARE the validators.",
   "keywords": [
     "rollup",

--- a/packages/consensus/package.json
+++ b/packages/consensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-consensus",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "PBFT consensus and leader rotation for the Raijin mesh rollup",
   "repository": {
     "type": "git",

--- a/packages/consensus/src/pbft.ts
+++ b/packages/consensus/src/pbft.ts
@@ -97,13 +97,22 @@ export class PBFTConsensus {
   /**
    * Sequence → digest of the last block that reached a PREPARE quorum
    * ("prepared certificate") at that sequence, across all views. Not
-   * cleared on view change — this is a partial mitigation for the lack of
-   * full prepared-certificate carry-over in NEW-VIEW: it stops a new leader
-   * from getting a *conflicting* block accepted at a sequence that was
-   * already validly prepared, even though it can't yet automatically
-   * re-propose the original block. See tracking issue for full carry-over.
+   * cleared on view change. Serves two purposes: `#handlePrePrepare` uses
+   * it to refuse a *conflicting* re-proposal at an already-prepared
+   * sequence, and `#doViewChange` uses it (together with `#preparedBlock`)
+   * to automatically carry the prepared block itself forward into the new
+   * view when this node becomes the new leader.
    */
   #preparedCert = new Map<string, Uint8Array>()
+  /**
+   * Sequence → the actual `Block` behind `#preparedCert`'s digest for that
+   * sequence. `#preparedCert` alone is enough to *reject* a conflicting
+   * proposal, but re-proposing the original block needs its full content,
+   * not just the digest that commits to it — so this is kept alongside it
+   * with the same lifecycle (set in `#onPrepared`, deleted in
+   * `#onCommitted`, never cleared by a view change).
+   */
+  #preparedBlock = new Map<string, Block>()
 
   // ── Timers ──
   #blockTimer: TimerHandle | null = null
@@ -335,7 +344,7 @@ export class PBFTConsensus {
 
     const count = this.#viewChanges.get(key)!.size
     if (count >= this.#validators.quorumSize()) {
-      this.#doViewChange(msg.newView)
+      await this.#doViewChange(msg.newView)
     }
   }
 
@@ -370,7 +379,7 @@ export class PBFTConsensus {
 
     if (seenSenders.size < this.#validators.quorumSize()) return
 
-    this.#doViewChange(msg.view)
+    await this.#doViewChange(msg.view)
   }
 
   // ── Prepare/Commit collection ───────────────────────────────────────
@@ -392,10 +401,17 @@ export class PBFTConsensus {
     if (this.#phase !== PBFTPhase.PrePrepared) return
     this.#phase = PBFTPhase.Prepared
 
-    // Record the prepared certificate for this sequence (see #preparedCert
-    // docs) — this survives view changes so a later view can't silently
-    // override an already-prepared block with a conflicting one.
+    // Record the prepared certificate — and the block it certifies — for
+    // this sequence (see #preparedCert / #preparedBlock docs). Both survive
+    // view changes: the digest so a later view can't silently override an
+    // already-prepared block with a conflicting one, the block so that if
+    // *this* node becomes the new leader it can automatically re-propose
+    // the very block it already prepared rather than only being able to
+    // reject conflicts.
     this.#preparedCert.set(this.#sequence.toString(), digest)
+    if (this.#pendingBlock) {
+      this.#preparedBlock.set(this.#sequence.toString(), this.#pendingBlock)
+    }
 
     // Sign the digest and send COMMIT
     const signature = await this.#signVote('commit', this.#view, this.#sequence, digest)
@@ -460,8 +476,10 @@ export class PBFTConsensus {
     this.#prepares.clear()
     this.#commits.clear()
     // This sequence is finalized — no future view change can conflict with
-    // it, so the prepared-certificate guard is no longer needed for it.
+    // it, so the prepared-certificate guard (and the block it would have
+    // carried forward) is no longer needed for it.
     this.#preparedCert.delete(finalizedSequence.toString())
+    this.#preparedBlock.delete(finalizedSequence.toString())
 
     // If we're the leader, schedule next block
     if (this.isLeader) {
@@ -495,16 +513,20 @@ export class PBFTConsensus {
   }
 
   /**
-   * Apply a view change. NOTE: this does not carry forward the highest
-   * prepared certificate from the old view (full PBFT view-change requires
-   * the new leader to re-propose any block that reached a PREPARE quorum in
-   * a prior view, at the same sequence). `#preparedCert` is a partial
-   * mitigation — see its docs and `#handlePrePrepare` — that prevents a
-   * *conflicting* re-proposal at an already-prepared sequence, but does not
-   * by itself get the original block re-proposed. Full carry-over is
-   * tracked as follow-up work.
+   * Apply a view change, carrying forward the highest prepared certificate
+   * from the old view: if this node becomes the new leader and already
+   * holds a prepared certificate (`#preparedCert` + `#preparedBlock`) for
+   * the current sequence, it automatically re-proposes that exact block
+   * under the new view instead of waiting for a fresh `propose()` call —
+   * which is what closes the gap `#preparedCert` alone could only guard
+   * (reject a conflicting re-proposal) but not fix (get the original block
+   * re-proposed so the round can still finalize). A new leader that never
+   * itself prepared the block (e.g. it was on the far side of a partition)
+   * has no certificate to carry and falls back to normal block production;
+   * `#handlePrePrepare`'s `#preparedCert` check still protects that case
+   * against a conflicting proposal from anyone.
    */
-  #doViewChange(newView: bigint): void {
+  async #doViewChange(newView: bigint): Promise<void> {
     if (newView <= this.#view) return
     this.#view = newView
     this.#phase = PBFTPhase.Idle
@@ -518,11 +540,55 @@ export class PBFTConsensus {
       handler(newView)
     }
 
-    // If we're the new leader, start proposing
     if (this.isLeader) {
-      this.#startBlockTimer()
+      const seqKey = this.#sequence.toString()
+      const carriedDigest = this.#preparedCert.get(seqKey)
+      const carriedBlock = this.#preparedBlock.get(seqKey)
+      if (carriedDigest && carriedBlock) {
+        await this.#reProposeCarried(carriedBlock, carriedDigest)
+      } else {
+        this.#startBlockTimer()
+      }
     }
     this.#resetViewTimer()
+  }
+
+  /**
+   * Re-propose, under the new (current) view, a block that already reached
+   * a PREPARE quorum at the current sequence in a prior view. Mirrors
+   * `propose()`'s PRE-PREPARE/PREPARE broadcast, except the sequence is not
+   * incremented and the digest is not recomputed — every honest replica
+   * that prepared this block already agrees on that exact digest, and
+   * recomputing it could only reproduce it or paper over a bug, never
+   * legitimately change it.
+   */
+  async #reProposeCarried(block: Block, digest: Uint8Array): Promise<void> {
+    this.#pendingBlock = block
+    this.#pendingDigest = digest
+    this.#phase = PBFTPhase.PrePrepared
+
+    const msg: PrePrepareMessage = {
+      type: 'pre-prepare',
+      view: this.#view,
+      sequence: this.#sequence,
+      block,
+      digest,
+      from: this.#identity,
+      signature: await this.#signVote('pre-prepare', this.#view, this.#sequence, digest),
+    }
+    this.#transport.broadcast(msg)
+
+    const prepareSignature = await this.#signVote('prepare', this.#view, this.#sequence, digest)
+    const prepare: PrepareMessage = {
+      type: 'prepare',
+      view: this.#view,
+      sequence: this.#sequence,
+      digest,
+      from: this.#identity,
+      signature: prepareSignature,
+    }
+    this.#transport.broadcast(prepare)
+    await this.#addPrepare(digest, this.#identity)
   }
 
   // ── Timers ──────────────────────────────────────────────────────────

--- a/packages/consensus/test/byzantine.test.ts
+++ b/packages/consensus/test/byzantine.test.ts
@@ -326,6 +326,65 @@ describe('Byzantine validators', () => {
 
       for (const p of [p2, p3, p4]) p.consensus.stop()
     })
+
+    /**
+     * The case the previous test had to fake: a new leader that HAD
+     * prepared the block itself. Full prepared-certificate carry-over means
+     * it does not need anyone to hand it the block — becoming leader is
+     * enough to make it re-propose what it already knows was prepared, and
+     * the cluster should actually finalize on it, not just fail to fork.
+     *
+     * Block X prepares on {k2, k3} this time (k2 is the leader of the next
+     * view), with the Byzantine leader withholding its own COMMIT so X
+     * stalls one vote short of a COMMIT quorum — prepared, not committed,
+     * same as the previous test, except now the future new leader is one of
+     * the two honest preparers instead of being ignorant of the round.
+     */
+    it('a new leader that already prepared the block automatically re-proposes and finalizes it', async () => {
+      const byz = makeTestKey(1) // leader for view 0
+      const k2 = makeTestKey(2) // leader for view 1
+      const k3 = makeTestKey(3)
+      const k4 = makeTestKey(4)
+      const validators = new ValidatorSet([byz, k2, k3, k4])
+
+      const p2 = honestPeer(k2, validators)
+      const p3 = honestPeer(k3, validators)
+      const p4 = honestPeer(k4, validators)
+
+      const blockX = makeBlock(1n, byz, 0x33)
+      const liar = new ByzantinePeer(byz, network.createTransport(byz), byzOpts(validators))
+      await liar.equivocate({
+        view: 0n,
+        sequence: 1n,
+        groups: [{ targets: [k2, k3], block: blockX }],
+        commit: false,
+      })
+      await settle()
+
+      // Prepared (2 honest + the liar's forged PREPARE = quorum 3), not
+      // committed (2 honest commits only — the liar withheld its COMMIT).
+      expect(p2.consensus.phase).toBe(PBFTPhase.Prepared)
+      expect(p3.consensus.phase).toBe(PBFTPhase.Prepared)
+      // k4 never saw a proposal at all.
+      expect(p4.consensus.phase).toBe(PBFTPhase.Idle)
+      expect([...p2.finalized, ...p3.finalized, ...p4.finalized]).toHaveLength(0)
+
+      // ── View change to view 1 — k2, the new leader, already prepared X ──
+      for (const p of [p2, p3, p4]) p.timer.advance(600)
+      await settle()
+
+      for (const p of [p2, p3, p4]) expect(p.consensus.currentView).toBe(1n)
+      expect(p2.consensus.isLeader).toBe(true)
+
+      // No external propose() call anywhere in this test: becoming leader
+      // must be enough by itself. The whole cluster converges on X.
+      for (const p of [p2, p3, p4]) {
+        expect(p.finalized).toHaveLength(1)
+        expect(blockTag(p.finalized[0])).toBe(0x33)
+      }
+
+      for (const p of [p2, p3, p4]) p.consensus.stop()
+    })
   })
 
   describe('an equivocating voter', () => {

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@johnhenry/raijin-core": "^0.0.1",
-    "@johnhenry/raijin-consensus": "^0.0.1",
-    "@johnhenry/raijin-validator": "^0.0.1"
+    "@johnhenry/raijin-consensus": "^0.0.2",
+    "@johnhenry/raijin-validator": "^0.0.2"
   },
   "devDependencies": {
     "vitest": "^3",

--- a/packages/test-harness/src/network/seeded-prng.ts
+++ b/packages/test-harness/src/network/seeded-prng.ts
@@ -25,7 +25,11 @@ export class SeededPRNG {
     s1 ^= s0 >> 26n
     this.#s1 = s1 & 0xFFFFFFFFFFFFFFFFn
     const result = ((this.#s0 + this.#s1) & 0xFFFFFFFFFFFFFFFFn)
-    return Number(result & 0x1FFFFFFFFFFFFFn) / 0x20000000000000
+    // xorshift128+'s low bits fail linearity tests that its high bits pass —
+    // the usual advice (and what splitmix64/xoshiro derivatives do) is to
+    // consume the top bits of the word, not the bottom ones. Shifting right
+    // by 11 keeps the high 53 bits of the 64-bit word for the float mantissa.
+    return Number(result >> 11n) / 0x20000000000000
   }
 
   /** Returns an integer in [0, max) */

--- a/packages/test-harness/test/network-faults.test.ts
+++ b/packages/test-harness/test/network-faults.test.ts
@@ -93,6 +93,33 @@ describe('PartitionableNetwork fault primitives', () => {
     expect(received).toEqual([1n])
   })
 
+  it('stops delaying an edge once removeDelay is called', async () => {
+    const { net, a, b, ta, received } = pair()
+    net.addDelay(a, b, 500)
+    net.removeDelay(a, b)
+    ta.send(b, note(1n))
+
+    // No delay recorded for the edge any more, so the message is
+    // deliverable immediately — no advanceTime needed.
+    expect(await net.drainAll()).toBe(1)
+    expect(received).toEqual([1n])
+  })
+
+  it('resetFaults clears partitions, delays and drop rates together', async () => {
+    const { net, a, b, ta, received } = pair(7)
+    net.partition([a], [b])
+    net.addDelay(a, b, 500)
+    net.addDropRate(a, b, 1)
+
+    net.resetFaults()
+
+    // Partition healed, delay gone, drop rate gone — a message sent now
+    // should arrive in this same drain, not be blocked, held or dropped.
+    ta.send(b, note(1n))
+    expect(await net.drainAll()).toBe(1)
+    expect(received).toEqual([1n])
+  })
+
   it('blocks a partitioned edge in both directions and restores it on heal', async () => {
     const { net, a, b, ta, received } = pair()
     net.partition([a], [b])

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-validator",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Composition root wiring core, consensus, and mempool into a runnable validator node",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "@johnhenry/raijin-core": "^0.0.1",
-    "@johnhenry/raijin-consensus": "^0.0.1",
+    "@johnhenry/raijin-consensus": "^0.0.2",
     "@johnhenry/raijin-mempool": "^0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- **#8 (HIGH):** `#doViewChange` now carries the prepared certificate forward — a new leader that already prepared a block itself automatically re-proposes it under the new view (no external `propose()` call needed), instead of only being able to reject a conflicting re-proposal. Falls back to normal block production if the new leader has no certificate for the sequence.
- **#28:** `SeededPRNG.next()` now draws from the high bits of its xorshift128+ state instead of the low bits; added test coverage for `removeDelay`/`resetFaults` (previously unexercised). The seeded-reordering primitive and most fault-injection coverage this issue asked for had already landed in a prior commit.
- **#27:** README test counts corrected (142→230 across the six publishable packages as more tests were added here, 25→27 harness tests) and a new "Validator-set size" section documents the `n - f` quorum formula and that `n >= 4` is required for any Byzantine fault tolerance.
- **#6** and **#26** were already fixed on `main` before this PR (commented and closed separately, with no code change needed).

`@johnhenry/raijin-consensus` bumped to 0.0.2 (behavior change). `@johnhenry/raijin-validator` bumped to 0.0.2 (dependency-range bump only, no code change) so a fresh install picks up the fixed consensus transitively.

## Test plan

- [x] `npm run build` — 6/6 packages
- [x] `npm run test` — all packages green, including a new end-to-end regression test for #8 (verified it fails without the fix, via a temporary revert)
- [x] `npm run typecheck` — 10/10
- [x] `npm run examples` — all 7 example smoke scripts pass