### PR TITLE
The Byzantine safety sweep asserted safety on seeds that decided nothing (#37)

### DIFF
--- a/packages/test-harness/src/checkers/no-fork.ts
+++ b/packages/test-harness/src/checkers/no-fork.ts
@@ -46,9 +46,19 @@ export class NoForkChecker implements Checker {
       }
     }
 
+    /*
+     * `heightsCompared` is reported so a caller can tell "no forks because
+     * consensus agreed" from "no forks because nothing was finalized".
+     *
+     * Both return `passed: true`, and they mean opposite things. When the
+     * round stalls, `blocksByHeight` is empty, the loop above runs zero
+     * times, and safety holds vacuously. A sweep built on this checker was
+     * passing on 5 of 6 seeds that finalized nothing at all.
+     */
     return {
       passed: true,
       message: `No forks detected across ${blocksByHeight.size} height(s) and ${nodes.size} node(s)`,
+      heightsCompared: blocksByHeight.size,
     }
   }
 }

--- a/packages/test-harness/src/orchestrator.ts
+++ b/packages/test-harness/src/orchestrator.ts
@@ -45,6 +45,13 @@ export interface CheckResult {
   passed: boolean
   message: string
   details?: string
+  /**
+   * How many distinct heights a checker actually compared, when it makes
+   * sense for that checker. A `passed: true` from zero comparisons means the
+   * property held vacuously, not that it was verified -- see NoForkChecker.
+   */
+  heightsCompared?: number
+
 }
 
 export class TestOrchestrator {

--- a/packages/test-harness/test/byzantine-proposer.test.ts
+++ b/packages/test-harness/test/byzantine-proposer.test.ts
@@ -170,6 +170,7 @@ describe('Byzantine proposer: 4-node cluster', () => {
    */
   it('cannot fork the cluster under any of a range of seeded message interleavings', async () => {
     let seedsThatFinalized = 0
+    const heightsBySeed = new Map<number, number>()
     for (const seed of [1, 2, 3, 7, 42, 1337]) {
       const { orch, liar, blockA, blockB } = await equivocatingCluster({ seed })
       orch.network.setDeliveryOrder('random')
@@ -186,6 +187,7 @@ describe('Byzantine proposer: 4-node cluster', () => {
 
       const noFork = await orch.check(new NoForkChecker())
       expect(noFork.passed, `seed ${seed}: ${noFork.details ?? ''}`).toBe(true)
+      heightsBySeed.set(seed, noFork.heightsCompared ?? 0)
 
       const finalized = [...orch.nodes.values()].flatMap((n) => n.finalizedBlocks)
       const tags = new Set(finalized.map((b) => b.header.txRoot[0]))
@@ -202,13 +204,38 @@ describe('Byzantine proposer: 4-node cluster', () => {
       }
     }
 
-    // Safety is trivial when nothing happens anywhere, so the sweep is only
-    // evidence if some of it actually reached a decision. As measured, 3 of
-    // these 6 seeds finalize and 3 stall on the dropped-out-of-order-vote
-    // behaviour described above; the assertion is left loose rather than
-    // pinned to 3, because that number is a property of the current message
-    // handling and not something a Byzantine test should freeze.
-    expect(seedsThatFinalized).toBeGreaterThan(0)
+    /*
+     * Safety is trivial when nothing happens anywhere, so the sweep is only
+     * evidence if some of it actually reached a decision.
+     *
+     * The comment here used to say "3 of these 6 seeds finalize and 3 stall",
+     * and left the assertion loose rather than pinned, on the reasoning that
+     * the number is a property of message handling and not a spec. That
+     * reasoning is sound and the looseness still hid a real regression:
+     * measured, ONE seed finalizes, not three. Five stall on the
+     * dropped-out-of-order-vote behaviour, NoForkChecker compares zero
+     * heights for each, and `passed: true` means nothing was verified. A
+     * `> 0` backstop passes at 1 of 6 exactly as it would at 1 of 100, so the
+     * drift from 3 to 1 produced no failure and the file went on documenting
+     * coverage it did not have.
+     *
+     * So the count is pinned -- not as a specification, but as a tripwire.
+     * If message handling changes and more seeds reach a decision, that is
+     * good news and this number should be raised deliberately, with the
+     * comment updated to match. What must not happen again is the number
+     * falling silently.
+     */
+    expect(
+      seedsThatFinalized,
+      'seeds reaching a decision changed; this is a property of message handling, ' +
+        'not a spec -- update the number and this comment deliberately. ' +
+        `Heights compared per seed: ${JSON.stringify([...heightsBySeed])}`,
+    ).toBe(1)
+
+    // And the sweep must have compared something somewhere, or every safety
+    // assertion above held vacuously.
+    const totalHeights = [...heightsBySeed.values()].reduce((a, b) => a + b, 0)
+    expect(totalHeights, 'the whole sweep verified nothing').toBeGreaterThan(0)
   })
 
   /**


### PR DESCRIPTION
Closes #37.

Measured on a clean checkout — finalized blocks per seed:

```
seed 1     finalized=0   0 height(s) compared
seed 2     finalized=0   0
seed 3     finalized=0   0
seed 7     finalized=2   1
seed 42    finalized=0   0
seed 1337  finalized=0   0
```

**Five of six seeds stall.** PBFT discards a PREPARE/COMMIT whose sequence doesn't match the current one and never re-requests it, so nothing finalizes. `NoForkChecker` then builds an empty `blocksByHeight`, its loop runs zero times, and it returns `passed: true`. The companion assertions degrade identically — `tags.size <= 1` compares 0 to 1, and `finalizedBlocks` is empty because **no** node finalized rather than because the isolated one was excluded.

The file's comment said *"3 of these 6 seeds finalize and 3 stall"*. **One does.** `expect(seedsThatFinalized).toBeGreaterThan(0)` passes at 1 of 6 exactly as it would at 1 of 100, so the drift from 3 to 1 produced no failure and the file went on documenting coverage it didn't have.

### Two changes

**`NoForkChecker` now reports `heightsCompared`.** "No forks because consensus agreed" and "no forks because nothing was finalized" both return `passed: true` and mean opposite things; a caller couldn't tell them apart.

**The sweep records that per seed and pins the count.** The original reasoning against pinning — that the number is a property of message handling, not a spec — is sound, and it's exactly what let the number fall silently. So it's pinned as a **tripwire**, with the failure message saying so: if message handling improves and more seeds decide, raise it deliberately and update the comment. A second assertion requires the sweep to have compared at least one height overall, or every safety assertion in it held vacuously.

### Verified

Asserting the old claim of 3 fails with:

> `Heights compared per seed: [[1,0],[2,0],[3,0],[7,1],[42,0],[1337,0]]`

That's the information that was missing.

**257 pass across 25 files.** `turbo typecheck --force` clean.