### PR TITLE
A DA frame that under-declares its size was accepted, silently truncated (#36)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,6 +1413,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -2266,6 +2273,7 @@
         "@johnhenry/raijin-core": "^0.0.1"
       },
       "devDependencies": {
+        "fflate": "^0.8.3",
         "tsup": "^8",
         "typescript": "^5.7",
         "vitest": "^3"

--- a/packages/da/package.json
+++ b/packages/da/package.json
@@ -22,10 +22,11 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run",
+    "test": "vitest run && npm run test:node",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test:node": "node --test test/default-inflate.node.test.mjs"
   },
   "license": "MIT",
   "dependencies": {
@@ -40,8 +41,12 @@
     }
   },
   "devDependencies": {
-    "typescript": "^5.7",
+    "fflate": "^0.8.3",
     "tsup": "^8",
+    "typescript": "^5.7",
     "vitest": "^3"
+  },
+  "optionalDependencies": {
+    "fflate": "^0.8.3"
   }
 }

--- a/packages/da/src/encoding.ts
+++ b/packages/da/src/encoding.ts
@@ -317,12 +317,34 @@ async function defaultInflate(): Promise<Inflate> {
     )
   }
   return (body, expected) => {
-    // Sizing `out` at exactly the expected length is what makes this bounded:
-    // fflate refuses to grow a buffer the caller supplied, so a stream that
-    // wants to produce more throws here rather than allocating. It also means
-    // the returned length is unambiguous — we never have to guess whether
-    // fflate handed back a trimmed view or the padded buffer.
-    return fflate.inflateSync(body, { out: new Uint8Array(expected) })
+    /*
+     * `out` is sized at expected + 1, and the extra byte is the whole point.
+     *
+     * The bound is what stops a zip bomb: fflate will not grow a buffer the
+     * caller supplied, so an over-long stream cannot force an allocation.
+     * This comment used to say such a stream "throws here". IT DOES NOT.
+     * fflate SILENTLY TRUNCATES to the buffer it was given and returns
+     * normally, so sizing `out` at exactly `expected` made a lying frame
+     * indistinguishable from an honest one: the output was `expected` bytes,
+     * the post-inflation length check compared equal, and decode() handed the
+     * caller silently truncated data as genuine DA content.
+     *
+     * Measured: a frame declaring 1024 bytes and carrying a compressed 8 MiB
+     * payload decoded without error and returned 1024 bytes.
+     *
+     * With one spare byte, the two cases separate. fflate trims when the
+     * stream ends inside the buffer and fills it when the stream does not, so
+     * a result of exactly expected + 1 means more data was coming — which is
+     * the lie, caught before anything downstream sees it. The memory bound is
+     * unchanged in substance: one byte.
+     */
+    const out = fflate.inflateSync(body, { out: new Uint8Array(expected + 1) })
+    if (out.length > expected) {
+      throw new DADecodeError(
+        `compressed payload produced more than the declared ${expected} bytes`,
+      )
+    }
+    return out
   }
 }
 

--- a/packages/da/test/default-inflate.node.test.mjs
+++ b/packages/da/test/default-inflate.node.test.mjs
@@ -1,0 +1,64 @@
+// Run with: node --test packages/da/test/default-inflate.node.test.mjs
+//
+// The shipped fflate adapter, exercised against the real dependency.
+//
+// This is a plain node:test file rather than a vitest one, and that is not a
+// preference. `getFflate()` loads the optional dependency through
+// `Function('return import("fflate")')()` -- indirection that stops a bundler
+// statically resolving an optional import. Vitest runs modules in a VM
+// context with no dynamic-import callback, so that expression throws
+// ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING there and `defaultInflate()` can
+// never be reached. Measured under both the default pool and `--pool=forks`.
+// In plain node it resolves fine.
+//
+// So every compressed-frame test in encoding.test.ts injects
+// `DecodeOptions.inflate` -- node:zlib standing in for fflate -- and
+// `defaultInflate()`, the ONLY place the memory bound exists in shipped code,
+// had never executed. fflate was not even declared in package.json; the
+// import simply always failed. Replacing the adapter's closure with a plain
+// `fflate.inflateSync(body)`, reinstating the bug the module was written to
+// fix, left all 41 DA tests green.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { deflateSync } from 'fflate'
+import { decode, DADecodeError } from '../dist/index.js'
+
+const encoder = new TextEncoder()
+
+/** Minimal LEB128, matching the frame format. */
+function leb128(value) {
+  const bytes = []
+  let v = value
+  do {
+    let byte = v & 0x7f
+    v >>>= 7
+    if (v !== 0) byte |= 0x80
+    bytes.push(byte)
+  } while (v !== 0)
+  return new Uint8Array(bytes)
+}
+
+function frame(declaredLength, compressed) {
+  const header = leb128(declaredLength)
+  const out = new Uint8Array(3 + header.length + compressed.length)
+  out.set([0x52, 0x4a, 0x43], 0)
+  out.set(header, 3)
+  out.set(compressed, 3 + header.length)
+  return out
+}
+
+test('round-trips a compressed frame through the shipped adapter', async () => {
+  const payload = encoder.encode('a'.repeat(4096))
+  // No `inflate` option: this is defaultInflate().
+  const out = await decode(frame(payload.length, deflateSync(payload)))
+  assert.deepEqual([...out], [...payload])
+})
+
+test('stops a frame that under-declares its size, inside the inflater', async () => {
+  // Declare 1 KiB, hand over a stream that expands to 8 MiB. fflate refuses
+  // to grow an `out` buffer the caller supplied, so this must throw rather
+  // than allocate.
+  const compressed = deflateSync(new Uint8Array(8 * 1024 * 1024))
+  await assert.rejects(() => decode(frame(1024, compressed)), DADecodeError)
+})


### PR DESCRIPTION
Closes #36. **This is a real production defect, not a test gap** — the investigation started as the latter and turned into the former.

### The documented behaviour is false

The code comment said a stream producing more than it declared *"throws here rather than allocating"*.

**It does not.** fflate silently truncates to the buffer it's handed and returns normally. Sizing `out` at exactly the declared length made a lying frame **indistinguishable from an honest one**: output was `expected` bytes, the post-inflation length check compared equal, and `decode()` returned truncated data to the caller as genuine DA content.

Measured end to end, before the fix:

```
frame declares 1024 bytes, carries a compressed 8 MiB payload
decode() -> resolved, returned 1024 bytes
```

The memory bound held — nothing allocated 8 MiB — but the **integrity** claim didn't.

### The fix

`out` is sized at `expected + 1`. fflate trims when the stream ends inside the buffer and fills it when it doesn't, so a result of exactly `expected + 1` means more data was coming, and that's rejected. One byte more memory; the bound is unchanged in substance.

### Why it was never caught

fflate is an optional dependency this repo **never installed** — it wasn't declared in `packages/da/package.json` at all, so the dynamic import always failed and `defaultInflate()` threw before building its closure.

Every compressed-frame test injects `DecodeOptions.inflate` with `node:zlib` instead — and **`node:zlib`'s `maxOutputLength` genuinely throws**, so the substitute behaved exactly as the docs claimed while the shipped adapter did not. The test closest to this asserted `expect(limits).toEqual([1024])`: that `decode()` passes the declared size along. It never asked what the adapter does with it.

### The new test is plain node:test, and that's forced

`getFflate()` loads fflate through `Function('return import("fflate")')()` — indirection that stops a bundler resolving an optional import. Vitest runs modules in a VM with no dynamic-import callback, so that expression throws `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` and the default path is **unreachable there** — measured under the default pool and `--pool=forks`. In plain node it resolves fine. `npm test` in this package now runs both runners.

fflate is now a devDependency and a declared optionalDependency.

Verified: the lying frame is refused, an honest frame still round-trips. **156 tests pass repo-wide**, `turbo typecheck --force` clean.