### PR TITLE
Two guards no test could distinguish (#38, #35)

### DIFF
--- a/packages/da/test/encoding.test.ts
+++ b/packages/da/test/encoding.test.ts
@@ -212,7 +212,50 @@ describe('DA encoding', () => {
       encoded.set(lengthHeader, 3)
       encoded.set(compressed, 3 + lengthHeader.length)
 
-      await expect(decode(encoded, { inflate: unboundedInflate })).rejects.toThrow(DADecodeError)
+      /*
+       * `DASizeLimitError extends DADecodeError`, so asserting the parent
+       * cannot tell the two adjacent guards apart. This input trips the
+       * declared-length check, NOT the size cap: `out.length > limit`
+       * compares 4 MiB against maxDecompressedSize (16 MiB) and is false, so
+       * only `out.length !== declared` fires. Deleting the size cap left this
+       * test green; deleting the length check fails it.
+       *
+       * Asserting the exact class pins which one is doing the work.
+       */
+      const rejection = await decode(encoded, { inflate: unboundedInflate }).then(
+        () => null,
+        (err: unknown) => err,
+      )
+      expect(rejection).toBeInstanceOf(DADecodeError)
+      expect(rejection).not.toBeInstanceOf(DASizeLimitError)
+      expect(String((rejection as Error).message)).toMatch(/declared/)
+    })
+
+    it('trips the size cap, distinguishably, when output exceeds it', async () => {
+      /*
+       * The guard the test above cannot reach. It needs output larger than
+       * `maxDecompressedSize`, not merely larger than the declared length --
+       * and it must be asserted as DASizeLimitError specifically, or the
+       * parent class swallows the distinction again.
+       */
+      const cap = 1024
+      const real = new Uint8Array(64 * 1024).fill(0x5a)
+      const compressed = deflate(real)
+
+      const lengthHeader = new Uint8Array([0x80, 0x08]) // LEB128 for 1024
+      const encoded = new Uint8Array(3 + lengthHeader.length + compressed.length)
+      encoded.set([0x52, 0x4a, 0x43], 0)
+      encoded.set(lengthHeader, 3)
+      encoded.set(compressed, 3 + lengthHeader.length)
+
+      const rejection = await decode(encoded, {
+        inflate: unboundedInflate,
+        maxDecompressedSize: cap,
+      }).then(
+        () => null,
+        (err: unknown) => err,
+      )
+      expect(rejection, 'the size cap fired, not the length check').toBeInstanceOf(DASizeLimitError)
     })
 
     it('honours a custom maxDecompressedSize', async () => {

--- a/packages/test-harness/test/partition.test.ts
+++ b/packages/test-harness/test/partition.test.ts
@@ -76,9 +76,35 @@ describe('Partition: 4-node cluster', () => {
     const ok = await orch.produceBlock(keys[0], keys[1], 25n)
     expect(ok).toBe(true)
 
+    /*
+     * Progress first, THEN agreement. Both checkers below pass vacuously when
+     * nothing was committed: GossipConvergenceChecker compares each node's
+     * LAST finalized block, so four nodes all still stuck at the pre-partition
+     * height 1 look perfectly converged, and NoForkChecker groups finalized
+     * blocks by height, so a height nobody reached is simply absent from the
+     * map.
+     *
+     * `ok` does not cover it either -- produceBlock returns true as soon as
+     * the leader yields a block and the network drains, without checking that
+     * a quorum committed. Injecting `if (this.#view > 0n) return` into PBFT's
+     * #onPrepared, so no round after any view change ever commits, left this
+     * test green while leader-crash.test.ts failed on exactly this assertion.
+     *
+     * The partition healed and a view change happened, so the whole point is
+     * that the network got PAST height 1.
+     */
+    for (const [id, node] of orch.nodes) {
+      expect(node.latestBlock!.header.number, `node ${id} advanced past the partition`).toBe(2n)
+    }
+
     // All nodes should converge
     const convergence = await orch.check(new GossipConvergenceChecker())
     expect(convergence.passed).toBe(true)
-    expect((await orch.check(new NoForkChecker())).passed).toBe(true)
+
+    const noFork = await orch.check(new NoForkChecker())
+    expect(noFork.passed).toBe(true)
+    // And it compared something: "no forks" across zero heights is not a
+    // safety result. See raijin#37.
+    expect(noFork.heightsCompared ?? 0, 'the fork check verified nothing').toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
Closes #38. Closes #35. Both are test gaps against correct production code.

### #38 — the DA size cap was indistinguishable from the check beside it

`DASizeLimitError extends DADecodeError`, and the very next check (`out.length !== declared`) throws a plain `DADecodeError` on the same input. The test asserted `rejects.toThrow(DADecodeError)` — which the parent matches either way.

The input doesn't even reach the cap: `out.length > limit` compares 4 MiB against `maxDecompressedSize` (16 MiB) and is **false**, so only the declared-length check fires. Deleting the cap left all 41 DA tests green; deleting the length check failed that same test — proving which guard it was really exercising.

The existing test now asserts the exact class it exercises and **refuses `DASizeLimitError` explicitly**. A new test reaches the cap by lowering `maxDecompressedSize` and asserts `DASizeLimitError` specifically — the parent class would swallow the distinction again.

### #35 — the partition test asserted agreement without progress

Both checkers pass vacuously when nothing commits. `GossipConvergenceChecker` compares each node's **last** finalized block, so four nodes all stuck at the pre-partition height 1 look perfectly converged. `NoForkChecker` groups by height, so a height nobody reached is simply absent.

`ok` from `produceBlock` doesn't cover it either — it returns true as soon as the leader yields a block and the network drains, without checking that a quorum committed.

The test now requires **every node to reach height 2** (the partition healed and a view change happened, so getting past height 1 is the whole point), and requires `NoForkChecker` to have compared at least one height — using the `heightsCompared` added in #37.

### Both verified against the issues' own injections

| injection | before | now |
|---|---|---|
| delete the DA size cap | 41 green | fails exactly one test |
| `if (this.#view > 0n) return` after `Prepared` | green | `node a advanced past the partition: expected 1n to be 2n` |

**181 tests pass repo-wide.** `turbo typecheck --force` clean.