### PR TITLE
Release 0.0.3: publish the DA under-declared-size fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.0.3 (2026-09-08)
+
+**`@johnhenry/raijin-da`**
+
+- **A frame that under-declares its size was accepted and silently
+  truncated.** `decodeFrame` sized the inflate buffer to the declared length
+  and trusted the result. fflate TRUNCATES rather than throwing when output
+  exceeds the buffer, so a frame declaring 1024 bytes while carrying 8 MiB
+  decoded "successfully" and returned the first 1024 bytes as genuine data —
+  a decompression bomb that reads as a valid frame. The buffer is now
+  allocated one byte over the declared size and anything that comes back
+  longer is refused; the extra byte is what makes the overflow detectable at
+  all. Fixed in f729485 (#36); this releases it.
+
+  Note this shipped as `0.0.1` on the registry WITHOUT the fix — the version
+  numbers matched while the code did not, so `npm i @johnhenry/raijin-da`
+  installed the vulnerable decoder. Publishing 0.0.2 is what actually ships
+  it.
+
 ## 0.0.2 (2026-09-06)
 
 **`@johnhenry/raijin-consensus`**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raijin",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Browser-native mesh rollup framework. Build sovereign rollups where the users ARE the validators.",
   "keywords": [
     "rollup",

--- a/packages/da/package.json
+++ b/packages/da/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@johnhenry/raijin-da",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Data availability abstraction with pluggable backends for the Raijin mesh rollup",
   "repository": {
     "type": "git",


### PR DESCRIPTION
```
packages/da  0.0.1 -> 0.0.2
root         0.0.2 -> 0.0.3   (release marker, as 0.0.2 was)
```

`raijin-da` is the only package whose published code differs from the tree. Checked by unpacking each tarball from the registry and diffing `src` — which is the point here, because **the version strings already matched**:

```
published 0.0.1:  fflate.inflateSync(body, { out: new Uint8Array(expected) })
repo:             out: new Uint8Array(expected + 1), and refuse anything longer
```

So `npm i @johnhenry/raijin-da` installs the **vulnerable decoder today**, at a version number identical to the fixed one. fflate truncates rather than throwing when output exceeds the buffer, so a frame declaring 1024 bytes while carrying 8 MiB decoded "successfully" and handed back the first 1024 bytes as genuine data.

The fix landed in `f729485` (#36) without a version bump. This is that bump.

The other five packages are byte-identical to what's published and are left alone. Nothing depends on `raijin-da`, so no ranges need updating.

### Two things that still block the publish itself

- **The Publish workflow has not succeeded since 2026-03-16** (#34), so this needs the same by-hand publish `0.0.2` got, or the token fixed first.
- **`publish.yml` runs `npm publish -w <pkg>` for all six unconditionally**, with no guard for versions already on the registry. A dispatched run would attempt to republish the five that haven't changed and fail on them. Only `packages/da` should go out.

Suite green.
